### PR TITLE
Semantic swaps + second-screen pages + Pupil reliability fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ htmlcov/
 node_modules/
 
 rust_native/*
+# Runtime session output (per-run experimental data, regenerates each run)
+assets/sessions/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Brief subagents like a new colleague: state the goal, the files/terms you alread
 - **Center sector (MC)** maps to a *random* corner in `frontend/public/main.js` `getOppositeSector` so changes always land in peripheral vision. Don't "fix" this.
 - **Session artefacts** land in `assets/sessions/<id>/` with `metadata.json`. Preserve the schema (`timestamp`, `sector`, `focus_sector`, `prompt`, `index`) — replay code depends on it.
 - **Prompt cycling**: `generation/sector_prompts.json` is the source of truth; `generation/prompts.txt` is the fallback. Each sector advances independently — don't reset all indices when editing one sector.
+- **Semantic mode state is in-memory**: `SemanticHistory` in `generation/semantic.py` lives per-process and per-session. A generation-service restart drops all captions and originals for the current session; the next `/generate` repopulates. Replays rely on `metadata.json.edit_history`, not on the in-memory dict.
+- **Idle auto-reset**: after `IDLE_RESET_SEC` (default 180 s) of no `/generate` and no `/session/start`, the generation service rotates to a new session automatically. Keep traffic flowing or bump the env var when scripting the pipeline.
 
 ## Running and testing
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 @dataclass
 class Settings:
-    zmq_endpoint: str = os.getenv("ARIA_ZMQ_ENDPOINT", "tcp://127.0.0.1:5555")
+    zmq_endpoint: str = os.getenv("BLINKPATCH_ZMQ_ENDPOINT", "tcp://127.0.0.1:5555")
     patch_dir: Path = Path(os.getenv("PATCH_ASSETS_DIR", "assets/patches")).resolve()
     sessions_dir: Path = Path(os.getenv("SESSIONS_ASSETS_DIR", "assets/sessions")).resolve()
     cors_origins: list[str] = field(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 class Settings:
     zmq_endpoint: str = os.getenv("ARIA_ZMQ_ENDPOINT", "tcp://127.0.0.1:5555")
     patch_dir: Path = Path(os.getenv("PATCH_ASSETS_DIR", "assets/patches")).resolve()
+    sessions_dir: Path = Path(os.getenv("SESSIONS_ASSETS_DIR", "assets/sessions")).resolve()
     cors_origins: list[str] = field(
         default_factory=lambda: os.getenv(
             "CORS_ORIGINS",
@@ -35,4 +36,5 @@ class Settings:
 def get_settings() -> Settings:
     settings = Settings()
     settings.patch_dir.mkdir(parents=True, exist_ok=True)
+    settings.sessions_dir.mkdir(parents=True, exist_ok=True)
     return settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,10 +17,10 @@ from .pupil_source import PupilSource
 from .stream import StreamHub
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
-logger = logging.getLogger("aria-backend")
+logger = logging.getLogger("blinkpatch-backend")
 
 settings = get_settings()
-app = FastAPI(title="Aria Gaze Patch Backend", version="0.1.0")
+app = FastAPI(title="BlinkPatch Backend", version="0.1.0")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ app.add_middleware(
     allow_credentials=True,
 )
 app.mount("/assets", StaticFiles(directory=str(settings.patch_dir)), name="assets")
+app.mount("/sessions", StaticFiles(directory=str(settings.sessions_dir)), name="sessions")
 
 stream_hub = StreamHub(history_size=settings.telemetry_history)
 patch_manager = PatchManager(settings.patch_dir)
@@ -111,6 +112,29 @@ async def register_patch_use(event: dict[str, Any]) -> dict[str, Any]:
     }
     patch_usage_log.append(record)
     return record
+
+
+@app.post("/events/generation")
+async def relay_generation(event: dict[str, Any]) -> dict[str, Any]:
+    """Generation service pings us after each save so observer/feed pages
+    can react without polling."""
+    await stream_hub.broadcast({"event": "generation", **event})
+    return {"ok": True}
+
+
+@app.post("/events/swap")
+async def relay_swap(event: dict[str, Any]) -> dict[str, Any]:
+    """Main frontend pings us when a pending image is actually swapped in."""
+    await stream_hub.broadcast({"event": "swap", **event})
+    return {"ok": True}
+
+
+@app.post("/events/session_started")
+async def relay_session_started(event: dict[str, Any]) -> dict[str, Any]:
+    """Generation service pings us on participant rollover so observer+feed can
+    reset their local state."""
+    await stream_hub.broadcast({"event": "session_started", **event})
+    return {"ok": True}
 
 
 @app.websocket("/ws/stream")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: docker/backend.Dockerfile
-    container_name: aria-backend
+    container_name: blinkpatch-backend
     environment:
       - PATCH_ASSETS_DIR=/app/assets/patches
       # The following are needed for the backend to connect to Pupil Core
@@ -21,13 +21,13 @@ services:
     ports:
       - "8000:8000"
     networks:
-      - aria-net
+      - blinkpatch-net
 
   generation:
     build:
       context: .
       dockerfile: docker/generation.Dockerfile
-    container_name: aria-generation
+    container_name: blinkpatch-generation
     env_file:
       - .env
     environment:
@@ -38,20 +38,20 @@ services:
     ports:
       - "8001:8001"
     networks:
-      - aria-net
+      - blinkpatch-net
 
   frontend:
     build:
       context: .
       dockerfile: docker/frontend.Dockerfile
-    container_name: aria-frontend
+    container_name: blinkpatch-frontend
     depends_on:
       - backend
     ports:
       - "8080:8080"
     networks:
-      - aria-net
+      - blinkpatch-net
 
 networks:
-  aria-net:
+  blinkpatch-net:
     driver: bridge

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -22,7 +22,7 @@ COPY backend ./backend
 COPY assets ./assets
 
 ENV PATCH_ASSETS_DIR=/app/assets/patches \
-    ARIA_ZMQ_ENDPOINT=tcp://relay:5555
+    BLINKPATCH_ZMQ_ENDPOINT=tcp://relay:5555
 
 EXPOSE 8000
 

--- a/docs/superpowers/plans/2026-04-22-semantic-swaps.md
+++ b/docs/superpowers/plans/2026-04-22-semantic-swaps.md
@@ -1,0 +1,1824 @@
+# Semantic Swaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace cycling prompts with a `GENERATION_MODE=semantic` path: each `/generate` call diverges from the prior 5 edits using a single multimodal OpenRouter request that returns both a modified image and a one-sentence caption; per-participant sessions rotate via an operator button or a 3-minute idle timer.
+
+**Architecture:** A new `generation/semantic.py` owns the per-session state (captions sliding window + cached original image) and the request/response shape. `generation/openrouter.py` gains a semantic variant that accepts an injectable `httpx.AsyncClient` for testing. `generation/server.py` branches `/generate` on `GENERATION_MODE`, handles rotation through `/session/start`, and runs a background idle task. `backend/app/main.py` fans out a new `session_started` WebSocket event. Observer and feed pages gain a `caption` preference, an edit-history card, and a "New Participant" button.
+
+**Tech Stack:** FastAPI, httpx (+ `httpx.MockTransport` for tests), Pillow, pytest, pytest-asyncio, vanilla ES-modules JavaScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-semantic-swaps-design.md`
+
+---
+
+## File map
+
+| Path | Role | Action |
+| --- | --- | --- |
+| `generation/semantic.py` | `SemanticHistory`, `build_prompt`, `parse_response`, degenerate-caption helper | Create |
+| `generation/openrouter.py` | Add `generate_with_openrouter_semantic`; make `client` injectable | Modify |
+| `generation/session_manager.py` | `save_generation` gains `caption`; metadata root gains `mode` and `edit_history` | Modify |
+| `generation/server.py` | Mode branch in `/generate`; rotation in `/session/start`; idle background task; notify backend | Modify |
+| `generation/requirements.txt` | (unchanged) | — |
+| `generation/requirements-dev.txt` | `pytest`, `pytest-asyncio` | Create |
+| `generation/tests/__init__.py` | Package marker | Create |
+| `generation/tests/conftest.py` | Fixtures: PNG bytes, fake OpenRouter response | Create |
+| `generation/tests/test_semantic.py` | Unit tests for `SemanticHistory`, `build_prompt`, `parse_response` | Create |
+| `generation/tests/test_openrouter_semantic.py` | `generate_with_openrouter_semantic` with `MockTransport` | Create |
+| `generation/tests/test_session_manager.py` | `save_generation` with caption; backwards-compat | Create |
+| `generation/tests/test_server_semantic.py` | Integration: `/generate` semantic branch + fallback | Create |
+| `backend/app/main.py` | New `POST /events/session_started` | Modify |
+| `frontend/public/observer.html` | Extra card + New Participant button | Modify |
+| `frontend/public/observer.js` | Wire session_started handler, rotation button, edit history | Modify |
+| `frontend/public/feed.js` | Prefer `caption`; reset on `session_started` | Modify |
+| `example.env` | Add `GENERATION_MODE=cycling` with comment | Modify |
+| `CLAUDE.md` | Mention semantic mode + idle reset | Modify |
+
+---
+
+## Task 1: Test scaffolding
+
+**Files:**
+- Create: `generation/requirements-dev.txt`
+- Create: `generation/tests/__init__.py`
+- Create: `generation/tests/conftest.py`
+- Create: `generation/pytest.ini`
+
+- [ ] **Step 1: Write `requirements-dev.txt`**
+
+```
+pytest>=8
+pytest-asyncio>=0.23
+```
+
+- [ ] **Step 2: Write empty `generation/tests/__init__.py`**
+
+```
+```
+
+- [ ] **Step 3: Write `generation/pytest.ini`**
+
+```ini
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+```
+
+- [ ] **Step 4: Write `generation/tests/conftest.py`**
+
+```python
+"""Shared fixtures for generation-service tests."""
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+
+def _tiny_png(color: tuple[int, int, int] = (12, 34, 56)) -> bytes:
+    img = Image.new("RGB", (16, 16), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def tiny_png_bytes() -> bytes:
+    return _tiny_png()
+
+
+@pytest.fixture
+def tiny_png_b64(tiny_png_bytes: bytes) -> str:
+    return f"data:image/png;base64,{base64.b64encode(tiny_png_bytes).decode()}"
+
+
+@pytest.fixture
+def fake_openrouter_response(tiny_png_b64: str):
+    """A minimal well-formed OpenRouter chat-completions payload."""
+    def _factory(caption: str | None = "a new soap bubble in the corner") -> dict:
+        content = f"CAPTION: {caption}" if caption is not None else "noop"
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": content,
+                        "images": [
+                            {"type": "image_url", "image_url": {"url": tiny_png_b64}}
+                        ],
+                    }
+                }
+            ]
+        }
+
+    return _factory
+```
+
+- [ ] **Step 5: Install dev deps locally for running tests**
+
+Run: `pip install -r generation/requirements-dev.txt -r generation/requirements.txt`
+Expected: clean install. If `fastapi`, `httpx`, `Pillow` already installed, pip reports `Requirement already satisfied`.
+
+- [ ] **Step 6: Confirm pytest discovers the empty suite**
+
+Run (from repo root): `cd generation && pytest -q`
+Expected: `no tests ran in 0.0Xs`. Exit code 5 is acceptable (no tests collected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add generation/requirements-dev.txt generation/pytest.ini generation/tests/__init__.py generation/tests/conftest.py
+git commit -m "test(generation): scaffold pytest suite"
+```
+
+---
+
+## Task 2: `SemanticHistory` class
+
+**Files:**
+- Create: `generation/semantic.py`
+- Create: `generation/tests/test_semantic.py`
+
+- [ ] **Step 1: Write the failing tests for `SemanticHistory`**
+
+Append to `generation/tests/test_semantic.py`:
+
+```python
+"""Tests for generation/semantic.py."""
+from __future__ import annotations
+
+from semantic import SemanticHistory
+
+
+def test_history_empty_for_unknown_session():
+    h = SemanticHistory()
+    assert h.captions("sess-a") == []
+    assert h.original("sess-a") is None
+
+
+def test_append_captions_respects_window_of_five():
+    h = SemanticHistory()
+    for i in range(8):
+        h.append("sess-a", f"edit {i}")
+    assert h.captions("sess-a") == [f"edit {i}" for i in range(3, 8)]
+
+
+def test_sessions_are_isolated():
+    h = SemanticHistory()
+    h.append("sess-a", "first")
+    h.append("sess-b", "other")
+    assert h.captions("sess-a") == ["first"]
+    assert h.captions("sess-b") == ["other"]
+
+
+def test_set_original_is_idempotent_per_session():
+    h = SemanticHistory()
+    h.set_original("sess-a", "data:image/png;base64,AAA")
+    h.set_original("sess-a", "data:image/png;base64,BBB")  # second call is a no-op
+    assert h.original("sess-a") == "data:image/png;base64,AAA"
+
+
+def test_clear_drops_captions_and_original():
+    h = SemanticHistory()
+    h.append("sess-a", "edit")
+    h.set_original("sess-a", "data:image/png;base64,AAA")
+    h.clear("sess-a")
+    assert h.captions("sess-a") == []
+    assert h.original("sess-a") is None
+```
+
+- [ ] **Step 2: Run tests (expect ImportError)**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: collection error / ImportError for `semantic`.
+
+- [ ] **Step 3: Write minimal `generation/semantic.py`**
+
+```python
+"""Per-session state for the semantic generation mode."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+HISTORY_WINDOW = 5
+
+
+@dataclass
+class SemanticHistory:
+    """In-memory, single-process state keyed by session id.
+
+    Holds the most recent `HISTORY_WINDOW` edit captions plus the original
+    (pre-edit) base image for each session. Persistence is explicitly not a
+    requirement — a fair demo is single-process and a fresh session starts on
+    process boot anyway.
+    """
+
+    _captions: dict[str, list[str]] = field(default_factory=dict)
+    _originals: dict[str, str] = field(default_factory=dict)
+
+    def captions(self, session_id: str) -> list[str]:
+        return list(self._captions.get(session_id, []))
+
+    def append(self, session_id: str, caption: str) -> None:
+        bucket = self._captions.setdefault(session_id, [])
+        bucket.append(caption)
+        if len(bucket) > HISTORY_WINDOW:
+            del bucket[: len(bucket) - HISTORY_WINDOW]
+
+    def original(self, session_id: str) -> str | None:
+        return self._originals.get(session_id)
+
+    def set_original(self, session_id: str, image_b64: str) -> None:
+        self._originals.setdefault(session_id, image_b64)
+
+    def clear(self, session_id: str) -> None:
+        self._captions.pop(session_id, None)
+        self._originals.pop(session_id, None)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add generation/semantic.py generation/tests/test_semantic.py
+git commit -m "feat(generation): add SemanticHistory for per-session captions + originals"
+```
+
+---
+
+## Task 3: `build_prompt`
+
+**Files:**
+- Modify: `generation/semantic.py`
+- Modify: `generation/tests/test_semantic.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `generation/tests/test_semantic.py`:
+
+```python
+from semantic import build_prompt
+
+
+def test_build_prompt_returns_two_images_then_text(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=[],
+        region=(0, 0, 100, 100),
+        sector_name="TL",
+    )
+    assert len(parts) == 3
+    assert parts[0]["type"] == "image_url"
+    assert parts[0]["image_url"]["url"] == tiny_png_b64
+    assert parts[1]["type"] == "image_url"
+    assert parts[2]["type"] == "text"
+
+
+def test_build_prompt_renders_region_bounds_and_sector(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=[],
+        region=(683, 0, 1024, 341),
+        sector_name="TR",
+    )
+    text = parts[2]["text"]
+    assert "(x1=683, y1=0, x2=1024, y2=341)" in text
+    assert "TR" in text
+
+
+def test_build_prompt_lists_captions_in_order(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=["first edit", "second edit", "third edit"],
+        region=(0, 0, 10, 10),
+        sector_name="MC",
+    )
+    text = parts[2]["text"]
+    assert '1. "first edit"' in text
+    assert '2. "second edit"' in text
+    assert '3. "third edit"' in text
+
+
+def test_build_prompt_says_no_prior_edits_when_empty(tiny_png_b64):
+    text = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 1, 1), "TL")[2]["text"]
+    assert "No prior edits yet" in text
+```
+
+- [ ] **Step 2: Run (expect failure)**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: ImportError for `build_prompt`.
+
+- [ ] **Step 3: Implement `build_prompt` in `generation/semantic.py`**
+
+Append to `generation/semantic.py`:
+
+```python
+def build_prompt(
+    original_b64: str,
+    current_b64: str,
+    captions: list[str],
+    region: tuple[int, int, int, int],
+    sector_name: str,
+) -> list[dict]:
+    """Assemble the `messages[0].content` payload for the semantic request."""
+    if captions:
+        history_block = "\n".join(
+            f'  {i + 1}. "{caption}"' for i, caption in enumerate(captions)
+        )
+    else:
+        history_block = "  (No prior edits yet.)"
+
+    x1, y1, x2, y2 = region
+    instruction = (
+        "You are editing an image for a change-blindness installation. A "
+        "participant is about to briefly look away from the region you are "
+        "modifying; they should only notice the change if they come back to "
+        "look at it directly.\n\n"
+        "IMAGE 1 is the ORIGINAL, unedited scene.\n"
+        "IMAGE 2 is the scene as it currently stands after several prior edits.\n\n"
+        "Prior edits applied in this session (most recent last):\n"
+        f"{history_block}\n\n"
+        "Your task:\n"
+        "- Propose ONE new edit, distinct in subject, scale, and style from every "
+        "prior edit above. Do not repeat motifs, colours, or object classes that "
+        "already appear.\n"
+        "- The edit MUST be visually contained within the pixel rectangle "
+        f"(x1={x1}, y1={y1}, x2={x2}, y2={y2}) - the {sector_name} sector of a "
+        "3x3 grid.\n"
+        "- The edit should make semantic sense given what is already in the "
+        "scene - it should feel like it belongs, not like a pasted sticker.\n"
+        "- Return the FULL modified image (not a crop), and a ONE-SENTENCE caption "
+        'of exactly what you added or changed, prefixed with "CAPTION:". '
+        "Example: CAPTION: a small paper boat now drifts across the puddle on the right."
+    )
+
+    return [
+        {"type": "image_url", "image_url": {"url": original_b64}},
+        {"type": "image_url", "image_url": {"url": current_b64}},
+        {"type": "text", "text": instruction},
+    ]
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: 9 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add generation/semantic.py generation/tests/test_semantic.py
+git commit -m "feat(generation): build_prompt for semantic swaps"
+```
+
+---
+
+## Task 4: `parse_response` and degenerate caption
+
+**Files:**
+- Modify: `generation/semantic.py`
+- Modify: `generation/tests/test_semantic.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `generation/tests/test_semantic.py`:
+
+```python
+from PIL import Image
+
+from semantic import degenerate_caption, parse_response
+
+
+def test_parse_response_extracts_image_and_caption(fake_openrouter_response):
+    resp = fake_openrouter_response("added a rainbow glow")
+    image, caption = parse_response(resp["choices"][0]["message"])
+    assert isinstance(image, Image.Image)
+    assert caption == "added a rainbow glow"
+
+
+def test_parse_response_without_caption_returns_none_caption(
+    fake_openrouter_response,
+):
+    resp = fake_openrouter_response(caption=None)  # content: "noop"
+    image, caption = parse_response(resp["choices"][0]["message"])
+    assert image is not None
+    assert caption is None
+
+
+def test_parse_response_missing_image_returns_none_image():
+    image, caption = parse_response({"content": "CAPTION: nothing"})
+    assert image is None
+    assert caption == "nothing"
+
+
+def test_parse_response_handles_list_content_with_caption(fake_openrouter_response):
+    resp = fake_openrouter_response("the fern uncurled")
+    message = resp["choices"][0]["message"]
+    message["content"] = [{"type": "text", "text": "CAPTION: the fern uncurled"}]
+    image, caption = parse_response(message)
+    assert caption == "the fern uncurled"
+
+
+def test_degenerate_caption_is_non_empty():
+    c = degenerate_caption(index=4, sector_name="TL")
+    assert "TL" in c
+    assert "4" in c
+```
+
+- [ ] **Step 2: Run (expect failure)**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: ImportError for `parse_response` / `degenerate_caption`.
+
+- [ ] **Step 3: Implement in `generation/semantic.py`**
+
+Append to `generation/semantic.py`:
+
+```python
+import time as _time
+from typing import Tuple
+
+from PIL import Image
+
+from openrouter import _extract_image
+
+CAPTION_PREFIX = "CAPTION:"
+
+
+def _extract_caption(content) -> str | None:
+    if isinstance(content, str):
+        for line in content.splitlines():
+            line = line.strip()
+            if line.startswith(CAPTION_PREFIX):
+                return line[len(CAPTION_PREFIX):].strip() or None
+        return None
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                captured = _extract_caption(item.get("text", ""))
+                if captured:
+                    return captured
+    return None
+
+
+def parse_response(message: dict) -> Tuple[Image.Image | None, str | None]:
+    """Return `(image_or_none, caption_or_none)` from a chat-completion message."""
+    image = _extract_image(message)
+    caption = _extract_caption(message.get("content", ""))
+    return image, caption
+
+
+def degenerate_caption(index: int, sector_name: str) -> str:
+    """Fallback caption when the model returned an image but no CAPTION line."""
+    return f"edit {index} in {sector_name} at {_time.strftime('%H:%M:%S')}"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd generation && pytest tests/test_semantic.py -q`
+Expected: 14 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add generation/semantic.py generation/tests/test_semantic.py
+git commit -m "feat(generation): parse_response and degenerate_caption helpers"
+```
+
+---
+
+## Task 5: Injectable client + `generate_with_openrouter_semantic`
+
+**Files:**
+- Modify: `generation/openrouter.py`
+- Create: `generation/tests/test_openrouter_semantic.py`
+
+- [ ] **Step 1: Refactor `openrouter.py` to accept an optional client**
+
+Replace the full body of `generate_with_openrouter` in `generation/openrouter.py` with:
+
+```python
+async def _post_chat(payload: dict, api_key: str, client: httpx.AsyncClient) -> dict:
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY not set")
+    response = await client.post(
+        f"{OPENROUTER_BASE_URL}/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/ubicomp-capstone",
+        },
+        json=payload,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"OpenRouter API error: {response.status_code} - {response.text}")
+    data = response.json()
+    choices = data.get("choices") or []
+    if not choices:
+        raise RuntimeError("No choices in OpenRouter response")
+    return choices[0].get("message", {})
+
+
+async def _with_client(client: httpx.AsyncClient | None):
+    """Context manager yielding a client; owns cleanup only when we created it."""
+    if client is not None:
+        return client, False
+    return httpx.AsyncClient(timeout=120.0), True
+
+
+async def generate_with_openrouter(
+    image: Image.Image,
+    prompt: str,
+    region: tuple[int, int, int, int],
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> Image.Image:
+    """Cycling-mode generation: one image in, one image out."""
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    img_b64 = base64.b64encode(buf.getvalue()).decode()
+    payload = {
+        "model": IMAGE_MODEL,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+                {
+                    "type": "text",
+                    "text": (
+                        f"Modify this image by adding or changing something in the region "
+                        f"from pixel ({region[0]}, {region[1]}) to ({region[2]}, {region[3]}). "
+                        f"The modification should be: {prompt}. Return the complete modified image."
+                    ),
+                },
+            ],
+        }],
+        "modalities": ["image", "text"],
+    }
+    owned, created = await _with_client(client)
+    try:
+        message = await _post_chat(payload, api_key, owned)
+    finally:
+        if created:
+            await owned.aclose()
+    image_out = _extract_image(message)
+    if image_out is None:
+        raise RuntimeError("Model did not return an image")
+    return image_out
+
+
+async def generate_with_openrouter_semantic(
+    content_parts: list[dict],
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> dict:
+    """Semantic-mode request. Returns the raw `message` dict so the caller can
+    parse image + caption itself."""
+    payload = {
+        "model": IMAGE_MODEL,
+        "messages": [{"role": "user", "content": content_parts}],
+        "modalities": ["image", "text"],
+    }
+    owned, created = await _with_client(client)
+    try:
+        return await _post_chat(payload, api_key, owned)
+    finally:
+        if created:
+            await owned.aclose()
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Write `generation/tests/test_openrouter_semantic.py`:
+
+```python
+"""Tests for the semantic OpenRouter call using httpx.MockTransport."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from openrouter import generate_with_openrouter_semantic
+from semantic import build_prompt, parse_response
+
+
+def _mock_transport(status: int, body: dict):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=body)
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_semantic_request_returns_message_on_success(
+    tiny_png_b64, fake_openrouter_response,
+):
+    response_body = fake_openrouter_response("a monarch butterfly drifted in")
+    transport = _mock_transport(200, response_body)
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        message = await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+        image, caption = parse_response(message)
+    assert image is not None
+    assert caption == "a monarch butterfly drifted in"
+
+
+@pytest.mark.asyncio
+async def test_semantic_request_raises_on_500(tiny_png_b64):
+    transport = _mock_transport(500, {"error": "boom"})
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        with pytest.raises(RuntimeError, match="OpenRouter API error: 500"):
+            await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+
+
+@pytest.mark.asyncio
+async def test_semantic_request_rejects_missing_api_key(tiny_png_b64):
+    transport = _mock_transport(200, {"choices": [{"message": {}}]})
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY not set"):
+            await generate_with_openrouter_semantic(parts, "", client=client)
+
+
+@pytest.mark.asyncio
+async def test_semantic_payload_carries_two_images_and_instructions(tiny_png_b64):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"choices": [{"message": {"content": "CAPTION: x", "images": [{"type": "image_url", "image_url": {"url": tiny_png_b64}}]}}]})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, ["prior edit"], (0, 0, 10, 10), "TL")
+        await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+
+    content = captured["body"]["messages"][0]["content"]
+    image_parts = [p for p in content if p["type"] == "image_url"]
+    assert len(image_parts) == 2
+    assert "prior edit" in [p for p in content if p["type"] == "text"][0]["text"]
+```
+
+- [ ] **Step 3: Run**
+
+Run: `cd generation && pytest tests/test_openrouter_semantic.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 4: Sanity-check existing cycling tests still pass**
+
+Run: `cd generation && pytest -q`
+Expected: 18 passed (14 from task 4 + 4 here). No regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add generation/openrouter.py generation/tests/test_openrouter_semantic.py
+git commit -m "feat(generation): semantic OpenRouter variant + injectable client"
+```
+
+---
+
+## Task 6: Extend `SessionManager` with caption, mode, edit_history
+
+**Files:**
+- Modify: `generation/session_manager.py`
+- Create: `generation/tests/test_session_manager.py`
+
+- [ ] **Step 1: Write failing tests**
+
+`generation/tests/test_session_manager.py`:
+
+```python
+"""Tests for SessionManager metadata extensions."""
+from __future__ import annotations
+
+import json
+
+from PIL import Image
+
+from session_manager import SessionManager
+
+
+def _tiny_image() -> Image.Image:
+    return Image.new("RGB", (8, 8), (1, 2, 3))
+
+
+def test_start_session_records_mode_when_passed_in_runtime(tmp_path):
+    sm = SessionManager(tmp_path)
+    sid = sm.start_new_session(runtime={"mode": "semantic"})
+    metadata = json.loads((tmp_path / sid / "metadata.json").read_text())
+    assert metadata["runtime"]["mode"] == "semantic"
+    assert metadata["edit_history"] == []
+
+
+def test_save_generation_persists_caption(tmp_path):
+    sm = SessionManager(tmp_path)
+    sid = sm.start_new_session(runtime={"mode": "semantic"})
+    entry = sm.save_generation(
+        _tiny_image(), "TL", "raw prompt", "BR",
+        caption="a bird landed on the ledge",
+    )
+    assert entry["caption"] == "a bird landed on the ledge"
+
+    metadata = json.loads((tmp_path / sid / "metadata.json").read_text())
+    assert metadata["sequence"][0]["caption"] == "a bird landed on the ledge"
+    assert metadata["edit_history"] == ["a bird landed on the ledge"]
+
+
+def test_edit_history_is_capped_at_five(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "semantic"})
+    for i in range(7):
+        sm.save_generation(_tiny_image(), "TL", "p", "BR", caption=f"c{i}")
+    assert sm.metadata["edit_history"] == ["c2", "c3", "c4", "c5", "c6"]
+
+
+def test_save_generation_without_caption_still_records_entry(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "cycling"})
+    entry = sm.save_generation(_tiny_image(), "TL", "p", "BR")
+    assert entry["caption"] is None
+    assert sm.metadata["edit_history"] == []
+
+
+def test_load_session_accepts_legacy_metadata_without_edit_history(tmp_path):
+    sid = "legacy-session"
+    folder = tmp_path / sid
+    folder.mkdir()
+    (folder / "metadata.json").write_text(json.dumps({
+        "session_id": sid,
+        "created_at": 0,
+        "sequence": [{"index": 0, "filename": "x.png", "target_sector": "TL",
+                       "focus_sector": "BR", "prompt": "p", "timestamp": 0}],
+    }))
+    sm = SessionManager(tmp_path)
+    metadata = sm.load_session(sid)
+    assert metadata["sequence"][0]["prompt"] == "p"
+```
+
+- [ ] **Step 2: Run (expect failure)**
+
+Run: `cd generation && pytest tests/test_session_manager.py -q`
+Expected: `caption` entries missing; `edit_history` missing → 4 failures.
+
+- [ ] **Step 3: Modify `generation/session_manager.py`**
+
+In `start_new_session`, replace the `self.metadata = { ... }` block with:
+
+```python
+        self.metadata = {
+            "session_id": session_id,
+            "created_at": time.time(),
+            "participant_id": participant_id,
+            "runtime": runtime or {},
+            "stats": {"blink_count": 0, "frame_drops": 0},
+            "calibration": None,
+            "edit_history": [],
+            "sequence": [],
+        }
+```
+
+Replace `save_generation` signature and body with:
+
+```python
+    def save_generation(
+        self,
+        image: Image.Image,
+        sector_name: str,
+        prompt: str,
+        focus_sector: str,
+        latency_ms: Optional[float] = None,
+        caption: Optional[str] = None,
+    ) -> Dict:
+        """Save a generated image and its metadata."""
+        if not self.current_session_dir:
+            raise ValueError("No active session. Call start_new_session() first.")
+
+        filename = f"{self.sequence_index:04d}_{sector_name}.png"
+        image_path = self.current_session_dir / filename
+        image.save(image_path, "PNG")
+
+        entry = {
+            "index": self.sequence_index,
+            "filename": filename,
+            "target_sector": sector_name,
+            "focus_sector": focus_sector,
+            "prompt": prompt,
+            "caption": caption,
+            "timestamp": time.time(),
+            "latency_ms": latency_ms,
+        }
+
+        self.metadata["sequence"].append(entry)
+        if caption:
+            history = self.metadata.setdefault("edit_history", [])
+            history.append(caption)
+            if len(history) > 5:
+                del history[: len(history) - 5]
+        self._save_metadata()
+
+        self.sequence_index += 1
+        lat = f", {latency_ms:.0f}ms" if latency_ms is not None else ""
+        print(f"Saved generation {self.sequence_index}: {sector_name}{lat}")
+        return entry
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd generation && pytest tests/test_session_manager.py -q`
+Expected: 5 passed.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `cd generation && pytest -q`
+Expected: 23 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add generation/session_manager.py generation/tests/test_session_manager.py
+git commit -m "feat(generation): persist caption and edit_history in session metadata"
+```
+
+---
+
+## Task 7: Wire the semantic branch in `/generate`
+
+**Files:**
+- Modify: `generation/server.py`
+- Create: `generation/tests/test_server_semantic.py`
+
+- [ ] **Step 1: Failing integration test**
+
+Write `generation/tests/test_server_semantic.py`:
+
+```python
+"""Integration tests for the /generate semantic branch."""
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _png_b64() -> str:
+    from PIL import Image
+    import io
+    img = Image.new("RGB", (24, 24), (9, 9, 9))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+@pytest.fixture
+def semantic_app(monkeypatch, tmp_path):
+    """Build a fresh FastAPI app in semantic mode with a tmp sessions dir."""
+    monkeypatch.setenv("GENERATION_MODE", "semantic")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fake-key")
+    monkeypatch.setenv("SESSIONS_DIR", str(tmp_path))
+    # Re-import so module-level env reads pick up the overrides.
+    import importlib, server
+    importlib.reload(server)
+    server.SESSIONS_DIR = tmp_path
+    server.session_manager.sessions_dir = tmp_path
+    yield server
+
+
+def _mock_transport(responses):
+    calls = iter(responses)
+    def handler(request):
+        status, body = next(calls)
+        return httpx.Response(status, json=body)
+    return httpx.MockTransport(handler)
+
+
+def test_semantic_generate_saves_caption_and_advances_history(
+    semantic_app, fake_openrouter_response,
+):
+    transport = _mock_transport([(200, fake_openrouter_response("added a rainbow"))])
+    with patch("openrouter.httpx.AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport)):
+        with TestClient(semantic_app.app) as client:
+            resp = client.post("/generate", json={
+                "image_base64": _png_b64(),
+                "focus_x": 0.5, "focus_y": 0.5,
+                "target_row": 0, "target_col": 0, "grid_size": 3,
+            })
+    assert resp.status_code == 200
+    session_id = semantic_app.session_manager.current_session_id
+    metadata_path = semantic_app.SESSIONS_DIR / session_id / "metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["sequence"][0]["caption"] == "added a rainbow"
+    assert metadata["edit_history"] == ["added a rainbow"]
+    assert semantic_app.semantic_history.captions(session_id) == ["added a rainbow"]
+
+
+def test_semantic_generate_falls_back_to_cycling_on_500(semantic_app):
+    """Two back-to-back 500s trigger retry then cycling fallback; caption empty."""
+    transport = _mock_transport([
+        (500, {"error": "first"}),
+        (500, {"error": "retry"}),
+        # cycling fallback call:
+        (200, {"choices": [{"message": {"images": [
+            {"type": "image_url", "image_url": {"url": _png_b64()}}
+        ]}}]}),
+    ])
+    with patch("openrouter.httpx.AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport)):
+        with TestClient(semantic_app.app) as client:
+            resp = client.post("/generate", json={
+                "image_base64": _png_b64(),
+                "focus_x": 0.5, "focus_y": 0.5,
+                "target_row": 0, "target_col": 0, "grid_size": 3,
+            })
+    assert resp.status_code == 200
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads((semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text())
+    assert metadata["sequence"][0]["caption"] is None
+    assert metadata["edit_history"] == []  # no semantic success → history unchanged
+
+
+def test_semantic_generate_synthesises_caption_when_model_omits_it(
+    semantic_app, fake_openrouter_response,
+):
+    transport = _mock_transport([(200, fake_openrouter_response(caption=None))])
+    with patch("openrouter.httpx.AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport)):
+        with TestClient(semantic_app.app) as client:
+            client.post("/generate", json={
+                "image_base64": _png_b64(),
+                "focus_x": 0.5, "focus_y": 0.5,
+                "target_row": 0, "target_col": 0, "grid_size": 3,
+            })
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads((semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text())
+    caption = metadata["sequence"][0]["caption"]
+    assert caption is not None
+    assert "TL" in caption
+```
+
+- [ ] **Step 2: Run (expect failure — semantic branch doesn't exist yet)**
+
+Run: `cd generation && pytest tests/test_server_semantic.py -q`
+Expected: 3 failures. Typical error: `module 'server' has no attribute 'semantic_history'`.
+
+- [ ] **Step 3: Add `GENERATION_MODE`, `SEMANTIC_HISTORY`, and branch to `server.py`**
+
+Near the top of `server.py`, under the other env vars, add:
+
+```python
+GENERATION_MODE = os.getenv("GENERATION_MODE", "cycling").lower()
+```
+
+Next to the other singletons, add:
+
+```python
+from semantic import (
+    SemanticHistory,
+    build_prompt,
+    degenerate_caption,
+    parse_response,
+)
+
+semantic_history = SemanticHistory()
+```
+
+Update `_runtime_snapshot`:
+
+```python
+def _runtime_snapshot() -> dict[str, Any]:
+    return {
+        "image_model": IMAGE_MODEL,
+        "mode": GENERATION_MODE,
+        "pupil_surface_name": PUPIL_SURFACE_NAME,
+        "pupil_confidence_threshold": PUPIL_CONFIDENCE_THRESHOLD,
+        "grid_size": GRID_SIZE,
+    }
+```
+
+In `startup_event`, add `global GENERATION_MODE` at the top of the function body and then, after the existing `session_id = ...` line, add:
+
+```python
+    global GENERATION_MODE
+    if GENERATION_MODE == "semantic" and not OPENROUTER_API_KEY:
+        print("GENERATION_MODE=semantic but OPENROUTER_API_KEY missing; coercing to cycling")
+        GENERATION_MODE = "cycling"
+```
+
+Replace the body of `generate()` starting at the `if OPENROUTER_API_KEY:` block with the full branching implementation:
+
+```python
+    async def _run_semantic() -> tuple[Image.Image, str | None]:
+        """Two-attempt semantic call; raises on terminal failure."""
+        session_id = session_manager.current_session_id or "anon"
+        semantic_history.set_original(session_id, request.image_base64)
+        captions = semantic_history.captions(session_id)
+        parts = build_prompt(
+            original_b64=semantic_history.original(session_id) or request.image_base64,
+            current_b64=request.image_base64,
+            captions=captions,
+            region=region,
+            sector_name=target,
+        )
+        from openrouter import generate_with_openrouter_semantic
+        try:
+            message = await generate_with_openrouter_semantic(parts, OPENROUTER_API_KEY)
+        except Exception as first_err:
+            print(f"semantic first attempt failed: {first_err} - retrying with terser prompt")
+            parts[-1]["text"] = (
+                "Propose one new small edit distinct from any prior edit, inside the "
+                f"pixel rectangle (x1={region[0]}, y1={region[1]}, x2={region[2]}, "
+                f"y2={region[3]}). Return the full modified image and a one-sentence "
+                'CAPTION: describing what you changed.'
+            )
+            message = await generate_with_openrouter_semantic(parts, OPENROUTER_API_KEY)
+        image, caption = parse_response(message)
+        if image is None:
+            raise RuntimeError("Semantic response had no image")
+        return image, caption
+
+    caption: str | None = None
+    semantic_success = False
+    duplicate_caption = False
+    if GENERATION_MODE == "semantic" and OPENROUTER_API_KEY:
+        try:
+            generated_image, caption = await _run_semantic()
+            semantic_success = True
+            session_id = session_manager.current_session_id or "anon"
+            prior = [c.lower() for c in semantic_history.captions(session_id)]
+            if caption and any(caption.lower() in p or p in caption.lower() for p in prior):
+                duplicate_caption = True
+            if caption is None:
+                caption = degenerate_caption(session_manager.sequence_index, target)
+        except Exception as sem_err:
+            print(f"semantic mode failed; falling back to cycling: {sem_err}")
+
+    if not semantic_success:
+        if OPENROUTER_API_KEY:
+            try:
+                generated_image = await generate_with_openrouter(
+                    init_image, prompt, region, OPENROUTER_API_KEY,
+                )
+            except Exception as api_err:
+                print(f"OpenRouter API failed: {api_err}")
+                generated_image = init_image
+        else:
+            print("No API key set - returning original image")
+            generated_image = init_image
+```
+
+Update the save call to pass `caption`:
+
+```python
+    latency_ms = (time.perf_counter() - t_start) * 1000
+    entry: dict = {}
+    if session_manager.current_session_id:
+        entry = session_manager.save_generation(
+            generated_image, target, prompt, focus_sector,
+            latency_ms=latency_ms, caption=caption,
+            duplicate_caption=duplicate_caption,
+        )
+        await _notify_backend(entry)
+        if semantic_success and caption:
+            semantic_history.append(session_manager.current_session_id, caption)
+```
+
+Extend `SessionManager.save_generation` to accept `duplicate_caption: bool = False` and include it in the entry only when true. In `generation/session_manager.py`, update the signature and body of `save_generation`:
+
+```python
+    def save_generation(
+        self,
+        image: Image.Image,
+        sector_name: str,
+        prompt: str,
+        focus_sector: str,
+        latency_ms: Optional[float] = None,
+        caption: Optional[str] = None,
+        duplicate_caption: bool = False,
+    ) -> Dict:
+        # ... existing body up to `entry = {...}` ...
+        entry = {
+            "index": self.sequence_index,
+            "filename": filename,
+            "target_sector": sector_name,
+            "focus_sector": focus_sector,
+            "prompt": prompt,
+            "caption": caption,
+            "timestamp": time.time(),
+            "latency_ms": latency_ms,
+        }
+        if duplicate_caption:
+            entry["duplicate_caption"] = True
+        # ... remainder unchanged ...
+```
+
+Add one more test for the flag to `generation/tests/test_server_semantic.py` (append, adjust `_mock_transport` list to deliver two successes with the same caption):
+
+```python
+def test_duplicate_caption_is_flagged(semantic_app, fake_openrouter_response):
+    body = fake_openrouter_response("a monarch butterfly appeared")
+    transport = _mock_transport([(200, body), (200, body)])
+    with patch("openrouter.httpx.AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport)):
+        with TestClient(semantic_app.app) as client:
+            for _ in range(2):
+                client.post("/generate", json={
+                    "image_base64": _png_b64(),
+                    "focus_x": 0.5, "focus_y": 0.5,
+                    "target_row": 0, "target_col": 0, "grid_size": 3,
+                })
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads((semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text())
+    assert metadata["sequence"][0].get("duplicate_caption") is not True
+    assert metadata["sequence"][1].get("duplicate_caption") is True
+```
+
+Update the outgoing backend notification: entries now carry `caption`, so the existing `**entry` splat already forwards it. No change there.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd generation && pytest tests/test_server_semantic.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `cd generation && pytest -q`
+Expected: 27 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add generation/server.py generation/tests/test_server_semantic.py
+git commit -m "feat(generation): GENERATION_MODE=semantic branch with terse retry + cycling fallback"
+```
+
+---
+
+## Task 8: `/session/start` rotates semantic history + notifies backend
+
+**Files:**
+- Modify: `generation/server.py`
+- Modify: `backend/app/main.py`
+- Modify: `generation/tests/test_server_semantic.py`
+
+- [ ] **Step 1: Add failing test for rotation**
+
+Append to `generation/tests/test_server_semantic.py`:
+
+```python
+def test_session_start_clears_semantic_history(semantic_app, fake_openrouter_response):
+    transport = _mock_transport([(200, fake_openrouter_response("first edit"))])
+    with patch("openrouter.httpx.AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport)):
+        with TestClient(semantic_app.app) as client:
+            client.post("/generate", json={
+                "image_base64": _png_b64(),
+                "focus_x": 0.5, "focus_y": 0.5,
+                "target_row": 0, "target_col": 0, "grid_size": 3,
+            })
+            old_sid = semantic_app.session_manager.current_session_id
+            assert semantic_app.semantic_history.captions(old_sid) == ["first edit"]
+
+            resp = client.post(
+                "/session/start",
+                json={"participant_id": "participant-42"},
+            )
+    assert resp.status_code == 200
+    new_sid = semantic_app.session_manager.current_session_id
+    assert new_sid != old_sid
+    assert semantic_app.semantic_history.captions(old_sid) == []
+    assert semantic_app.semantic_history.captions(new_sid) == []
+```
+
+- [ ] **Step 2: Run (expect failure — old session's captions still present)**
+
+Run: `cd generation && pytest tests/test_server_semantic.py::test_session_start_clears_semantic_history -q`
+Expected: assertion error on the `captions(old_sid) == []` line.
+
+- [ ] **Step 3: Modify `/session/start` in `server.py`**
+
+Replace the existing `start_session` handler with:
+
+```python
+@app.post("/session/start")
+async def start_session(req: Optional[StartSessionRequest] = None) -> dict:
+    req = req or StartSessionRequest()
+    prev_sid = session_manager.current_session_id
+    sid = session_manager.start_new_session(
+        session_id=req.session_id,
+        participant_id=req.participant_id,
+        runtime=_runtime_snapshot(),
+    )
+    if prev_sid and prev_sid != sid:
+        semantic_history.clear(prev_sid)
+    if _backend_client is not None:
+        try:
+            await _backend_client.post(
+                f"{BACKEND_URL}/events/session_started",
+                json={"session_id": sid, "participant_id": req.participant_id},
+                timeout=2.0,
+            )
+        except Exception as exc:
+            print(f"session_started relay failed: {exc}")
+    return {"session_id": sid, "status": "recording", "participant_id": req.participant_id}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd generation && pytest tests/test_server_semantic.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Add backend `/events/session_started` endpoint**
+
+In `backend/app/main.py`, add next to the existing relay endpoints:
+
+```python
+@app.post("/events/session_started")
+async def relay_session_started(event: dict[str, Any]) -> dict[str, Any]:
+    """Generation service pings us on participant rollover so observer+feed can
+    reset their local state."""
+    await stream_hub.broadcast({"event": "session_started", **event})
+    return {"ok": True}
+```
+
+- [ ] **Step 6: Syntax-check backend**
+
+Run: `python3 -m py_compile backend/app/main.py`
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add generation/server.py generation/tests/test_server_semantic.py backend/app/main.py
+git commit -m "feat: rotate semantic history on /session/start + relay to backend"
+```
+
+---
+
+## Task 9: Idle auto-reset background task
+
+**Files:**
+- Modify: `generation/server.py`
+- Modify: `generation/tests/test_server_semantic.py`
+
+- [ ] **Step 1: Failing test for idle reset**
+
+Append to `generation/tests/test_server_semantic.py`:
+
+```python
+import time
+
+
+async def test_idle_reset_rotates_session_when_stale(semantic_app):
+    from server import _maybe_idle_reset
+    sm = semantic_app.session_manager
+    first = sm.current_session_id
+    now = time.time()
+    semantic_app._last_generation_ts = now - 240
+    semantic_app._last_session_started_ts = now - 240
+
+    await _maybe_idle_reset()
+    assert sm.current_session_id != first
+
+
+async def test_idle_reset_is_noop_when_recent(semantic_app):
+    from server import _maybe_idle_reset
+    sm = semantic_app.session_manager
+    first = sm.current_session_id
+    now = time.time()
+    semantic_app._last_generation_ts = now - 30
+    semantic_app._last_session_started_ts = now - 30
+    await _maybe_idle_reset()
+    assert sm.current_session_id == first
+```
+
+- [ ] **Step 2: Run (expect ImportError)**
+
+Run: `cd generation && pytest tests/test_server_semantic.py::test_idle_reset_rotates_session_when_stale -q`
+Expected: ImportError for `_maybe_idle_reset`.
+
+- [ ] **Step 3: Add idle task plumbing to `server.py`**
+
+Near the other module-level state add:
+
+```python
+IDLE_THRESHOLD_SEC = int(os.getenv("IDLE_RESET_SEC", "180"))
+IDLE_TICK_SEC = 30
+
+_last_generation_ts = time.time()
+_last_session_started_ts = time.time()
+_idle_task: asyncio.Task | None = None
+_idle_lock = asyncio.Lock()
+```
+
+At the top of the file add `import asyncio` if not already present.
+
+In `generate()`, update `_last_generation_ts` at the very end just before the `return Response(...)`:
+
+```python
+    global _last_generation_ts
+    _last_generation_ts = time.time()
+```
+
+In the rewritten `start_session` (from Task 8), at the end before `return`, update `_last_session_started_ts`:
+
+```python
+    global _last_session_started_ts
+    _last_session_started_ts = time.time()
+```
+
+Add the helper and background loop:
+
+```python
+async def _maybe_idle_reset() -> None:
+    """If neither /generate nor /session/start has fired for IDLE_THRESHOLD_SEC,
+    rotate to a new session. Skips if a generation is in flight (we can tell
+    because the lock will be held by /generate)."""
+    async with _idle_lock:
+        now = time.time()
+        stale = (
+            now - _last_generation_ts > IDLE_THRESHOLD_SEC
+            and now - _last_session_started_ts > IDLE_THRESHOLD_SEC
+        )
+        if not stale:
+            return
+        # Equivalent to POST /session/start with no participant_id:
+        prev_sid = session_manager.current_session_id
+        sid = session_manager.start_new_session(runtime=_runtime_snapshot())
+        if prev_sid and prev_sid != sid:
+            semantic_history.clear(prev_sid)
+        global _last_session_started_ts
+        _last_session_started_ts = now
+        if _backend_client is not None:
+            try:
+                await _backend_client.post(
+                    f"{BACKEND_URL}/events/session_started",
+                    json={"session_id": sid, "participant_id": None},
+                    timeout=2.0,
+                )
+            except Exception as exc:
+                print(f"idle session_started relay failed: {exc}")
+        print(f"Idle rotation: new session {sid}")
+
+
+async def _idle_watcher() -> None:
+    while True:
+        await asyncio.sleep(IDLE_TICK_SEC)
+        try:
+            await _maybe_idle_reset()
+        except Exception as exc:
+            print(f"idle watcher error: {exc}")
+```
+
+In `startup_event`, start the task:
+
+```python
+    global _idle_task
+    _idle_task = asyncio.create_task(_idle_watcher())
+```
+
+In `shutdown_event`:
+
+```python
+    if _idle_task is not None:
+        _idle_task.cancel()
+```
+
+Wrap the pre-existing `generate()` body in `async with _idle_lock:` (entire `/generate` handler) so the idle task cannot fire mid-generation. The outermost structure becomes:
+
+```python
+@app.post("/generate")
+async def generate(request: GenerateRequest) -> Response:
+    async with _idle_lock:
+        t_start = time.perf_counter()
+        # ... existing body unchanged ...
+        global _last_generation_ts
+        _last_generation_ts = time.time()
+        return Response(...)
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd generation && pytest tests/test_server_semantic.py -q`
+Expected: 7 passed.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `cd generation && pytest -q`
+Expected: 29 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add generation/server.py generation/tests/test_server_semantic.py
+git commit -m "feat(generation): 3-minute idle auto-reset background task"
+```
+
+---
+
+## Task 10: Observer UI — New Participant button + Edit history + session_started reset
+
+**Files:**
+- Modify: `frontend/public/observer.html`
+- Modify: `frontend/public/observer.js`
+
+- [ ] **Step 1: Add UI elements to `observer.html`**
+
+In the sidebar, rename "Last prompt" to "Last edit" and add two new cards + a button. Replace the existing `.sidebar` div contents with:
+
+```html
+    <div class="sidebar">
+      <div class="card">
+        <h3>Participant</h3>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <input id="participant-input" type="text" placeholder="id (optional)"
+                 style="flex:1; padding:8px; border-radius:6px; border:1px solid rgba(255,255,255,0.15); background:#05070f; color:inherit;" />
+          <button id="new-participant-btn"
+                  style="padding:8px 12px; border:0; border-radius:6px; background:#00e5ff; color:#05070f; font-weight:600; cursor:pointer;">
+            New
+          </button>
+        </div>
+        <div id="participant-banner" style="margin-top:8px; font-size:12px; opacity:0; transition:opacity 300ms;"></div>
+      </div>
+      <div class="card">
+        <h3>Generations</h3>
+        <div class="stat" id="stat-generations">0</div>
+      </div>
+      <div class="card">
+        <h3>Swaps</h3>
+        <div class="stat">
+          <span id="stat-swaps">0</span>
+          <span class="sub">caught <span id="stat-caught">0</span></span>
+        </div>
+      </div>
+      <div class="card">
+        <h3>Last edit</h3>
+        <div class="prompt" id="last-caption">&mdash;</div>
+      </div>
+      <div class="card">
+        <h3>Edit history</h3>
+        <ol id="edit-history" style="margin:0; padding-left:20px; font-size:13px; line-height:1.5; max-height:180px; overflow-y:auto;"></ol>
+      </div>
+      <div class="card">
+        <h3>Last generation</h3>
+        <div class="mini" id="last-image"></div>
+      </div>
+    </div>
+```
+
+- [ ] **Step 2: Wire the button + history + reset in `observer.js`**
+
+Replace the full body of `observer.js` with:
+
+```javascript
+import { API_ROOT, loadRuntimeConfig } from "./config.js";
+import { openStream } from "./ws.js";
+import { gazeToSector, sectorName } from "./sectors.js";
+
+const DETECTION_WINDOW_MS = 1500;
+const EDIT_HISTORY_MAX = 10;
+
+const stage = document.getElementById("stage");
+const grid = document.getElementById("grid");
+const cursor = document.getElementById("cursor");
+const lastCaptionEl = document.getElementById("last-caption");
+const editHistoryEl = document.getElementById("edit-history");
+const lastImageEl = document.getElementById("last-image");
+const statGenerations = document.getElementById("stat-generations");
+const statSwaps = document.getElementById("stat-swaps");
+const statCaught = document.getElementById("stat-caught");
+const participantInput = document.getElementById("participant-input");
+const newParticipantBtn = document.getElementById("new-participant-btn");
+const participantBanner = document.getElementById("participant-banner");
+
+async function main() {
+  const config = await loadRuntimeConfig();
+  const cells = buildGrid(config.grid_size);
+  let state = initialState();
+
+  newParticipantBtn.addEventListener("click", async () => {
+    const id = participantInput.value.trim() || null;
+    try {
+      await fetch(`${config.generation_api}/session/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ participant_id: id }),
+      });
+    } catch (err) {
+      console.warn("New Participant POST failed", err);
+    }
+  });
+
+  function resetForNewSession(participantId) {
+    state = initialState();
+    statGenerations.textContent = "0";
+    statSwaps.textContent = "0";
+    statCaught.textContent = "0";
+    lastCaptionEl.textContent = "—";
+    editHistoryEl.innerHTML = "";
+    lastImageEl.style.backgroundImage = "";
+    for (const row of cells) for (const cell of row) cell.classList.remove("focus", "modified");
+    participantBanner.textContent = participantId
+      ? `New participant: ${participantId}`
+      : "New participant";
+    participantBanner.style.opacity = "1";
+    setTimeout(() => (participantBanner.style.opacity = "0"), 2000);
+  }
+
+  function setFocus(sector) {
+    if (state.focusSector) cells[state.focusSector.row][state.focusSector.col].classList.remove("focus");
+    state.focusSector = sector;
+    if (state.focusSector) cells[state.focusSector.row][state.focusSector.col].classList.add("focus");
+  }
+
+  function flashModified(sector) {
+    const cell = cells[sector.row][sector.col];
+    cell.classList.add("modified");
+    setTimeout(() => cell.classList.remove("modified"), 1200);
+  }
+
+  function positionCursor(smoothed, stale) {
+    const rect = stage.getBoundingClientRect();
+    cursor.style.left = `${smoothed.x_norm * rect.width}px`;
+    cursor.style.top = `${smoothed.y_norm * rect.height}px`;
+    cursor.style.display = "block";
+    cursor.classList.toggle("stale", stale);
+  }
+
+  function pushEditHistory(caption) {
+    if (!caption) return;
+    const li = document.createElement("li");
+    li.textContent = caption;
+    editHistoryEl.prepend(li);
+    while (editHistoryEl.children.length > EDIT_HISTORY_MAX) {
+      editHistoryEl.lastChild.remove();
+    }
+  }
+
+  openStream({
+    sample: ({ gaze }) => {
+      if (!gaze) return;
+      if (gaze.valid) state.lastValidTs = Date.now();
+      const stale = Date.now() - state.lastValidTs > config.gaze_stale_ms;
+      if (!gaze.valid || stale) {
+        cursor.style.display = "none";
+        setFocus(null);
+        return;
+      }
+      positionCursor(gaze, false);
+      const sector = gazeToSector(gaze, config.grid_size);
+      if (!state.focusSector
+          || sector.row !== state.focusSector.row
+          || sector.col !== state.focusSector.col) {
+        setFocus(sector);
+        if (state.pendingDetection
+            && sector.row === state.pendingDetection.targetSector.row
+            && sector.col === state.pendingDetection.targetSector.col
+            && Date.now() < state.pendingDetection.deadline) {
+          state.caught += 1;
+          statCaught.textContent = state.caught;
+          state.pendingDetection = null;
+        }
+      }
+    },
+
+    generation: ({ session_id, filename, prompt, caption }) => {
+      state.generations += 1;
+      statGenerations.textContent = state.generations;
+      const label = caption || prompt || "";
+      lastCaptionEl.textContent = label || "—";
+      pushEditHistory(caption);
+      if (session_id && filename) {
+        lastImageEl.style.backgroundImage = `url(${API_ROOT}/sessions/${session_id}/${filename})`;
+      }
+    },
+
+    swap: ({ target_row, target_col }) => {
+      state.swaps += 1;
+      statSwaps.textContent = state.swaps;
+      if (typeof target_row === "number" && typeof target_col === "number") {
+        const target = { row: target_row, col: target_col };
+        flashModified(target);
+        state.pendingDetection = {
+          targetSector: target,
+          deadline: Date.now() + DETECTION_WINDOW_MS,
+        };
+      }
+    },
+
+    session_started: ({ participant_id }) => {
+      resetForNewSession(participant_id);
+    },
+  });
+}
+
+function initialState() {
+  return {
+    focusSector: null,
+    generations: 0,
+    swaps: 0,
+    caught: 0,
+    pendingDetection: null,
+    lastValidTs: 0,
+  };
+}
+
+function buildGrid(gridSize) {
+  grid.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
+  grid.style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
+  grid.innerHTML = "";
+  const cells = [];
+  for (let r = 0; r < gridSize; r++) {
+    cells[r] = [];
+    for (let c = 0; c < gridSize; c++) {
+      const el = document.createElement("div");
+      el.className = "cell";
+      el.textContent = sectorName({ row: r, col: c });
+      grid.appendChild(el);
+      cells[r][c] = el;
+    }
+  }
+  return cells;
+}
+
+main();
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run the stack (`docker compose up --build` or `scripts/start_stack.sh`).
+Open `http://localhost:8080/observer.html`.
+Expected:
+- Sidebar shows Participant card with an input and New button.
+- Clicking **New** (empty input) posts to `/session/start`; a banner flashes; counters reset.
+- Type `p1`, click **New**. Banner reads "New participant: p1". `assets/sessions/<new-session-id>/metadata.json` has `participant_id: "p1"`.
+- Trigger a generation on the main page; observer shows caption under "Last edit" and prepends it to "Edit history". Thumbnail updates.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/public/observer.html frontend/public/observer.js
+git commit -m "feat(observer): new participant button + edit history + session reset"
+```
+
+---
+
+## Task 11: Feed UI — caption preference + session reset
+
+**Files:**
+- Modify: `frontend/public/feed.js`
+
+- [ ] **Step 1: Replace the full body of `feed.js`**
+
+```javascript
+import { API_ROOT } from "./config.js";
+import { openStream } from "./ws.js";
+
+const stage = document.getElementById("stage");
+const waiting = document.getElementById("waiting");
+const sectorEl = document.getElementById("sector");
+const promptEl = document.getElementById("prompt");
+
+let currentImg = null;
+
+function clearStage() {
+  if (currentImg) {
+    currentImg.remove();
+    currentImg = null;
+  }
+  waiting.style.display = "grid";
+  sectorEl.textContent = "";
+  promptEl.textContent = "";
+}
+
+function showGeneration({ session_id, filename, target_sector, prompt, caption }) {
+  if (!session_id || !filename) return;
+  const img = new Image();
+  img.src = `${API_ROOT}/sessions/${session_id}/${filename}`;
+  img.onload = () => {
+    waiting.style.display = "none";
+    if (currentImg) currentImg.classList.add("prev");
+    stage.appendChild(img);
+    requestAnimationFrame(() => {
+      if (currentImg) currentImg.remove();
+      currentImg = img;
+    });
+  };
+  sectorEl.textContent = target_sector || "";
+  promptEl.textContent = caption || prompt || "";
+}
+
+openStream({
+  generation: showGeneration,
+  session_started: clearStage,
+});
+```
+
+- [ ] **Step 2: Manual verification**
+
+Open `http://localhost:8080/feed.html` alongside a main page session. Trigger a generation — caption should appear in the bottom-right italic line (preferred over raw prompt). Click **New** on observer — feed clears and shows "Waiting for first generation…".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/public/feed.js
+git commit -m "feat(feed): prefer caption and reset on session_started"
+```
+
+---
+
+## Task 12: Docs + example.env
+
+**Files:**
+- Modify: `example.env`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add env vars to `example.env`**
+
+Append to `example.env`:
+
+```bash
+# Generation mode: "semantic" uses image-conditioned prompts with a 5-edit sliding
+# window of captions; "cycling" uses the hand-authored prompts.txt / sector_prompts.json.
+# Defaults to cycling for safe rollout.
+GENERATION_MODE=cycling
+
+# Idle reset window (seconds) before the generation service auto-rotates to a
+# new participant session. Applies to both semantic and cycling modes.
+IDLE_RESET_SEC=180
+```
+
+- [ ] **Step 2: Add a semantic-mode gotcha to `CLAUDE.md`**
+
+Append under "Project-specific gotchas":
+
+```markdown
+- **Semantic mode state is in-memory**: `SemanticHistory` in `generation/semantic.py` lives per-process and per-session. A generation-service restart drops all captions and originals for the current session; next `/generate` repopulates. Replays rely on `metadata.json.edit_history`, not on the in-memory dict.
+- **Idle auto-reset**: after 180 s of no `/generate` and no `/session/start`, the generation service auto-rotates to a new session. If you script the pipeline, either keep traffic flowing or bump `IDLE_RESET_SEC`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add example.env CLAUDE.md
+git commit -m "docs: document semantic mode env vars and idle reset"
+```
+
+---
+
+## Task 13: Final verification
+
+- [ ] **Step 1: Full unit + integration suite**
+
+Run: `cd generation && pytest -q`
+Expected: 29 passed.
+
+- [ ] **Step 2: Byte-compile all touched Python**
+
+Run: `python3 -m py_compile generation/server.py generation/openrouter.py generation/semantic.py generation/session_manager.py backend/app/main.py`
+Expected: no output.
+
+- [ ] **Step 3: Smoke-test the stack**
+
+1. Set `OPENROUTER_API_KEY` and `GENERATION_MODE=semantic` in `.env`.
+2. `docker compose up --build`.
+3. Open main page, observer, and feed.
+4. Perform 5+ gaze fixations → verify:
+   - `assets/sessions/<sid>/metadata.json` shows `runtime.mode = "semantic"`, each entry has a non-null `caption`, `edit_history` has up to 5 entries.
+   - Observer "Edit history" lists the last ~5 captions.
+   - Feed italic text mirrors the caption, not the raw prompt.
+5. Click **New** on observer → new session folder appears, observer counters zeroed, feed clears.
+6. Leave idle 3+ minutes → new session folder appears automatically; generation-service logs "Idle rotation: new session ...".
+7. Unset `OPENROUTER_API_KEY`, restart generation service → logs coerce to cycling; `/generate` still returns 200 with the original image.
+
+- [ ] **Step 4: Final commit for any lint / drift**
+
+```bash
+git status
+# if clean: skip
+# else:
+git add -A
+git commit -m "chore: final tidy-up after semantic-swaps rollout"
+```
+
+---
+
+## Out of scope (covered by follow-up specs)
+
+- Souvenir highlight-reel video (recommendation #1 from earlier).
+- CI workflow (recommendation #2).
+- Observer UI test automation.
+- Semantic mode over multiple generation-service replicas (requires a shared store for `SemanticHistory`).

--- a/docs/superpowers/specs/2026-04-22-semantic-swaps-design.md
+++ b/docs/superpowers/specs/2026-04-22-semantic-swaps-design.md
@@ -1,0 +1,201 @@
+# Semantic Swaps with Cumulative Divergence
+
+**Status:** Design
+**Date:** 2026-04-22
+**Owner:** DSteinmann
+
+## Problem
+
+Today every participant sees the same hand-curated prompts cycling in a fixed order. For a science-art fair we want every participant's session to feel unique, and we want the peripheral edits to interact semantically with whatever is already on screen rather than reading as pasted stickers.
+
+## Non-goals
+
+- Participant-supplied input (theme, mood, text). Scene-only semantics for v1.
+- Per-visitor souvenir videos, printouts, or leaderboards. Separate feature.
+- Replacing the gaze / fixation / blink pipeline. Unchanged.
+- CI, Playwright end-to-end suite, or full test-automation rollout.
+
+## Summary
+
+A new `semantic` generation mode (selected by env var) sends each `/generate` call through a single multimodal OpenRouter request that reasons about the current scene, diverges from the last five in-session edits, and returns both the modified image and a one-sentence caption of what it changed. Captions are the unit of history that distinguishes one participant's trajectory from another's. Sessions are participant-scoped: an operator button on the observer tablet starts a new session, and a 3-minute idle timer auto-rotates if the operator forgets.
+
+## Architecture
+
+```
+frontend /generate (unchanged request shape)
+        |
+        v
+generation service (GENERATION_MODE=semantic)
+    |-- sectors.py              (unchanged pixel bounds)
+    |-- semantic.py              (NEW: history, prompt builder, response parser)
+    |-- openrouter.py            (image+caption extraction)
+    |-- session_manager.py       (stores caption per entry; clears per session)
+    |-- /generate                (branches on mode; fallback chain for failures)
+    |-- /session/start           (rotates session, clears SemanticHistory)
+        |
+        v
+backend /events/generation       (carries caption alongside prompt)
+backend /events/session_started  (new, broadcast on participant rollover)
+        |
+        v
+observer.html  |  feed.html      (consume caption, reset on session_started)
+```
+
+No change to the frontend gaze / fixation / WebSocket pipeline. No change to sector geometry. The only cross-service surface additions are the `caption` field on `generation` events and the new `session_started` event.
+
+## Prompt design
+
+Each `/generate` call in semantic mode issues one OpenRouter chat-completion request with modalities `["image", "text"]`.
+
+**User message content (in order):**
+
+1. `image_url` — the original, unedited base image for the session.
+2. `image_url` — the current evolved scene (what the frontend just posted).
+3. `text` — instruction block, templated:
+
+```
+You are editing an image for a change-blindness installation. A participant is
+about to briefly look away from the region you are modifying; they should only
+notice the change if they come back to look at it directly.
+
+IMAGE 1 is the ORIGINAL, unedited scene.
+IMAGE 2 is the scene as it currently stands after several prior edits.
+
+Prior edits applied in this session (most recent last):
+  1. "<caption>"
+  2. "<caption>"
+  ... up to 5 ...
+
+Your task:
+- Propose ONE new edit, distinct in subject, scale, and style from every prior
+  edit above. Do not repeat motifs, colours, or object classes that already
+  appear.
+- The edit MUST be visually contained within the pixel rectangle
+  (x1=..., y1=..., x2=..., y2=...) - the <SECTOR_NAME> sector of a 3x3 grid.
+- The edit should make semantic sense given what is already in the scene -
+  it should feel like it belongs, not like a pasted sticker.
+- Return the FULL modified image (not a crop), and a ONE-SENTENCE caption of
+  exactly what you added or changed, prefixed with "CAPTION:". Example:
+  CAPTION: a small paper boat now drifts across the puddle on the right.
+```
+
+**Response parsing:**
+
+- `message.images[0]` yields the modified image (existing path in `openrouter.py`).
+- `message.content` is scanned for a line starting with `CAPTION:`; the prefix is stripped. If absent, a degenerate caption is synthesised as `edit #N in <sector> at HH:MM:SS` so history still advances.
+
+**History:** `SemanticHistory` is an in-memory `dict[str, list[str]]` keyed by `session_id`. `append(sid, caption)` pushes and slices to the last five. `clear(sid)` drops the key. Fine for single-process runtime; persistence is not required for fair operation.
+
+**Original-image capture:** The generation service has no persistent notion of the base image today. On the first `/generate` call of a session, the incoming `image_base64` is cached in a new `SemanticHistory.originals: dict[str, str]` (keyed by `session_id`). Subsequent calls for that session pass both the cached original and the fresh incoming image into `build_prompt`. `clear(sid)` drops the original alongside the captions so participant rollover is atomic.
+
+**Sliding window:** 5 captions. Large enough to prevent short-loop repetition, small enough to keep request size flat after long sessions.
+
+## Session and participant lifecycle
+
+A session equals one participant. Three triggers roll it over:
+
+1. **Operator button** on the observer tablet. Sends `POST {GENERATION_API}/session/start` with an optional `participant_id`. The generation service creates a new `session_<timestamp>/` folder, clears `SemanticHistory[prev_session_id]`, and calls backend `POST /events/session_started`.
+2. **Idle auto-rotate.** A background task in the generation service ticks every 30 s. If no `/generate` has fired for more than 3 min *and* the last `session_started` was more than 3 min ago, it fires `start_new_session()` internally, mirroring the operator path. Skipped if a generation is in flight.
+3. **Startup.** Existing behaviour: one session is auto-started on process boot. No change.
+
+Backend exposes `POST /events/session_started` → broadcasts `{event: "session_started", session_id, participant_id}` via the existing WebSocket. Observer and feed both listen and reset their local UI state (counters, thumbnail, edit-history list, feed image).
+
+Future: a "first-valid-gaze after idle" auto-start in the backend. Out of scope for v1.
+
+## Data and metadata
+
+**`SessionManager.save_generation`** gains `caption: Optional[str] = None`. Stored under `caption` on the metadata entry alongside `prompt`.
+
+**Session metadata root** gains:
+
+- `mode: "semantic" | "cycling"` — written into `runtime` at session start so replays are reproducible.
+- `edit_history: list[str]` — snapshot of the sliding window written on every `save_generation`. Cheap and keeps the metadata file self-describing.
+
+**New module `generation/semantic.py`:**
+
+- `class SemanticHistory` with `append(session_id, caption)`, `window(session_id, n=5) -> list[str]`, `clear(session_id)`.
+- `build_prompt(original_b64, current_b64, captions, region, sector_name) -> list[dict]` — pure, unit-testable.
+- `parse_response(message: dict) -> tuple[Image.Image | None, str | None]` — wraps the existing `_extract_image` and adds caption parsing.
+- `generate_semantic(...)` — orchestrates the request + parse. Lives in `semantic.py` or `openrouter.py` (implementation choice during planning).
+
+**`generation/server.py`:**
+
+- Env var `GENERATION_MODE` (`semantic` | `cycling`, default `cycling`).
+- `/generate` branches on mode. Only the payload builder and response parser differ; sector math, session save, backend notification are shared.
+- `/session/start` clears the previous session's entry in `SemanticHistory` and calls backend `/events/session_started`.
+- Idle background task (3-min threshold, 30-s tick).
+
+**`backend/app/main.py`:** new `POST /events/session_started` endpoint that broadcasts to WS clients. No other changes.
+
+**Event shape changes:**
+
+- `generation` WS event adds a `caption` field.
+- New `session_started` WS event.
+
+**Backwards compatibility:** all new metadata fields are optional. Old session folders still load. Observer and feed tolerate missing `caption` by falling back to `prompt`.
+
+## UI surfaces
+
+**Feed (`feed.html` / `feed.js`)**
+
+- Bottom-right italic line prefers `caption`; falls back to `prompt`.
+- On `session_started`: clear the current image, re-show the "Waiting for first generation…" overlay.
+
+**Observer (`observer.html` / `observer.js`)**
+
+- Rename the "Last prompt" card to "Last edit"; show `caption` (or `prompt` fallback).
+- New card **"Edit history"**: scrollable list, up to 10 captions, newest first.
+- New sidebar button **"New Participant"** with a small text input for `participant_id` (blank = anonymous). Clicking sends `POST ${GENERATION_API}/session/start`.
+- On `session_started`: reset generation / swap / caught counters, clear edit-history list, clear thumbnail and grid highlights, flash "New participant: <id>" banner for 2 s.
+
+The generation service base URL is already delivered by `/config`; reuse it for the button.
+
+## Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| OpenRouter HTTP error or timeout | Retry once with a terser prompt. If that also fails, fall back to the cycling-prompt path for this call only; session stays in semantic mode. |
+| Response has text but no image | Same as above: terser retry, then cycling fallback. |
+| Response has image but no `CAPTION:` line | Accept the image. Synthesise `edit #N in <sector> at HH:MM:SS` as the caption so history still advances. Log a warning. |
+| Caption is a near-duplicate of a prior caption (case-insensitive substring against the 5-window) | Accept anyway and flag the entry with `duplicate_caption: true`. Do not attempt model-level de-duplication. |
+| `GENERATION_MODE=semantic` but `OPENROUTER_API_KEY` missing at startup | Log a clear error and coerce the mode to `cycling`. Demo continues. |
+| `SemanticHistory[current_session_id]` missing (process restart mid-session) | Treat as empty history for this call. Next save repopulates. No crash. |
+| Idle-reset fires while a generation is in flight | Skip this tick; check again in 30 s. |
+
+Caption and history are advanced only on genuine semantic successes. Fallbacks 1-2 do not grow the history.
+
+No new exception classes. All fallbacks remain inside `/generate`; the HTTP contract is unchanged.
+
+## Testing
+
+**Unit tests** in a new `generation/tests/` directory:
+
+- `test_semantic.py`
+  - `build_prompt` with 0, 3, 5, and 8 captions (sliding-window behaviour).
+  - `build_prompt` with varying sectors — verify rectangle text matches `calculate_sector_region`.
+  - `parse_response` extracts caption from well-formed content; returns `None` on missing caption; still returns the image.
+  - `SemanticHistory.clear()` on session rollover; isolation between session IDs.
+- `test_sectors.py` — pure-function tests for the grid math extracted during the earlier refactor.
+- `test_session_manager.py` — `save_generation` with a caption; backwards-compat with legacy `metadata.json` files that predate the field.
+
+**Integration tests** using `httpx.MockTransport` to stub OpenRouter:
+
+- Success path: image + caption, history appended, metadata saved.
+- Image-only response: degenerate caption synthesised, `duplicate_caption` logic skipped.
+- HTTP 500: retry fires, then cycling fallback kicks in; history length unchanged.
+- Missing API key: mode coerced to cycling; no exception surfaces to the frontend.
+
+**Manual QA checklist** to run during fair rehearsal:
+
+- 10-swap session in semantic mode. Verify captions in `metadata.json`, no duplicate flags in the first 5 edits, observer edit-history list scrolls, feed shows captions.
+- Hit "New Participant" mid-session. Verify feed clears, observer counters reset, new session folder exists, semantic history cleared.
+- Leave the system idle for 3+ minutes. Verify a new session folder appears automatically.
+- Remove the OpenRouter API key and run again. Verify silent fallback to cycling, no 5xx responses to the frontend.
+
+**Out of scope for this spec:** CI workflow, Playwright end-to-end for the observer, load testing.
+
+## Rollout
+
+- `GENERATION_MODE=cycling` remains the default. Flip to `semantic` per environment when ready.
+- Semantic can be A/B'd at a fair by alternating sessions between modes via the operator button + an env toggle on the tablet. Sessions are self-describing so analysis is straightforward.
+- Revert path: flip the env var back to `cycling`. No schema migration, no data-loss risk.

--- a/example.env
+++ b/example.env
@@ -1,5 +1,4 @@
 # Compose environment overrides
-ARIA_DEVICE_ID=NEEDED_IF_ARIA_IS_USED
 OPENROUTER_API_KEY=YOUR_KEY_HERE
 
 # Generation mode: "semantic" uses image-conditioned prompts with a 5-edit sliding

--- a/example.env
+++ b/example.env
@@ -1,3 +1,12 @@
 # Compose environment overrides
 ARIA_DEVICE_ID=NEEDED_IF_ARIA_IS_USED
 OPENROUTER_API_KEY=YOUR_KEY_HERE
+
+# Generation mode: "semantic" uses image-conditioned prompts with a 5-edit sliding
+# window of captions; "cycling" uses the hand-authored prompts.txt / sector_prompts.json.
+# Defaults to cycling for safe rollout.
+GENERATION_MODE=cycling
+
+# Idle reset window (seconds) before the generation service auto-rotates to a
+# new participant session. Applies to both semantic and cycling modes.
+IDLE_RESET_SEC=180

--- a/frontend/public/feed.html
+++ b/frontend/public/feed.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Generation Feed</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #05070f;
+      color: #e6f1ff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      overflow: hidden;
+    }
+    .stage {
+      position: fixed;
+      inset: 0;
+      display: grid;
+      place-items: center;
+    }
+    .stage img {
+      max-width: 100vw;
+      max-height: 100vh;
+      object-fit: contain;
+      transition: opacity 400ms ease;
+    }
+    .stage img.prev { position: absolute; opacity: 0; }
+    .meta {
+      position: fixed;
+      bottom: 24px;
+      left: 24px;
+      right: 24px;
+      display: flex;
+      justify-content: space-between;
+      font-size: 14px;
+      opacity: 0.75;
+      pointer-events: none;
+    }
+    .meta .sector {
+      font-weight: 600;
+      letter-spacing: 2px;
+    }
+    .meta .prompt {
+      max-width: 60ch;
+      text-align: right;
+      font-style: italic;
+    }
+    .waiting {
+      position: fixed;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 20px;
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+  <div class="stage" id="stage"></div>
+  <div class="waiting" id="waiting">Waiting for first generation…</div>
+  <div class="meta">
+    <span class="sector" id="sector"></span>
+    <span class="prompt" id="prompt"></span>
+  </div>
+  <script type="module" src="feed.js"></script>
+</body>
+</html>

--- a/frontend/public/feed.js
+++ b/frontend/public/feed.js
@@ -1,0 +1,28 @@
+import { API_ROOT } from "./config.js";
+import { openStream } from "./ws.js";
+
+const stage = document.getElementById("stage");
+const waiting = document.getElementById("waiting");
+const sectorEl = document.getElementById("sector");
+const promptEl = document.getElementById("prompt");
+
+let currentImg = null;
+
+function showGeneration({ session_id, filename, target_sector, prompt }) {
+  if (!session_id || !filename) return;
+  const img = new Image();
+  img.src = `${API_ROOT}/sessions/${session_id}/${filename}`;
+  img.onload = () => {
+    waiting.style.display = "none";
+    if (currentImg) currentImg.classList.add("prev");
+    stage.appendChild(img);
+    requestAnimationFrame(() => {
+      if (currentImg) currentImg.remove();
+      currentImg = img;
+    });
+  };
+  sectorEl.textContent = target_sector || "";
+  promptEl.textContent = prompt || "";
+}
+
+openStream({ generation: showGeneration });

--- a/frontend/public/feed.js
+++ b/frontend/public/feed.js
@@ -8,7 +8,17 @@ const promptEl = document.getElementById("prompt");
 
 let currentImg = null;
 
-function showGeneration({ session_id, filename, target_sector, prompt }) {
+function clearStage() {
+  if (currentImg) {
+    currentImg.remove();
+    currentImg = null;
+  }
+  waiting.style.display = "grid";
+  sectorEl.textContent = "";
+  promptEl.textContent = "";
+}
+
+function showGeneration({ session_id, filename, target_sector, prompt, caption }) {
   if (!session_id || !filename) return;
   const img = new Image();
   img.src = `${API_ROOT}/sessions/${session_id}/${filename}`;
@@ -22,7 +32,10 @@ function showGeneration({ session_id, filename, target_sector, prompt }) {
     });
   };
   sectorEl.textContent = target_sector || "";
-  promptEl.textContent = prompt || "";
+  promptEl.textContent = caption || prompt || "";
 }
 
-openStream({ generation: showGeneration });
+openStream({
+  generation: showGeneration,
+  session_started: clearStage,
+});

--- a/frontend/public/generation.js
+++ b/frontend/public/generation.js
@@ -1,5 +1,6 @@
 import { sectorName, sectorToNormCenter, getOppositeSector, gazeToSector } from "./sectors.js";
 import { setActivePatch } from "./rendering.js";
+import { API_ROOT } from "./config.js";
 
 export class GenerationController {
   constructor(config, gazeStream, fixationTracker) {
@@ -95,6 +96,17 @@ export class GenerationController {
     setActivePatch({ image: this.pendingSwap.image });
     this.capturedImageBase64 = this.pendingSwap.base64;
     console.log(`✓ Image swapped! Modified sector: ${sectorName(targetSector)}`);
+    fetch(`${API_ROOT}/events/swap`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        target_sector: sectorName(targetSector),
+        focus_sector: sectorName(this.pendingSwap.focusSector),
+        target_row: targetSector.row,
+        target_col: targetSector.col,
+        timestamp: Date.now() / 1000,
+      }),
+    }).catch(() => {});
     this.pendingSwap = null;
     this.fixation.reset();
   }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Aria Blink Patch Demo</title>
+  <title>Gaze-Contingent Change Blindness Demo</title>
   <link rel="stylesheet" href="styles.css" />
   <style>
     .apriltag-marker {

--- a/frontend/public/main.js
+++ b/frontend/public/main.js
@@ -4,7 +4,7 @@ import { GazeStream } from "./gaze.js";
 import { FixationTracker } from "./fixation.js";
 import { GenerationController } from "./generation.js";
 
-const DEFAULT_BASE_IMAGE = `${API_ROOT}/assets/generated/a-single-banana-on-a-white-background-in-the-upp-p1-1765812893-00.png`;
+const DEFAULT_BASE_IMAGE = `${API_ROOT}/assets/generated/pexels-triemli-28578413.jpg`;
 
 async function loadDefaultBaseImage(controller) {
   try {

--- a/frontend/public/observer.html
+++ b/frontend/public/observer.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Observer</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: #05070f;
+      color: #e6f1ff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      overflow: hidden;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 280px;
+      height: 100vh;
+      gap: 16px;
+      padding: 16px;
+      box-sizing: border-box;
+    }
+    .stage {
+      position: relative;
+      background: #0b1329;
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .grid {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: repeat(3, 1fr);
+    }
+    .cell {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: grid;
+      place-items: center;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 2px;
+      color: rgba(255, 255, 255, 0.15);
+      transition: background 300ms ease, color 300ms ease;
+    }
+    .cell.focus { background: rgba(0, 229, 255, 0.14); color: rgba(255,255,255,0.7); }
+    .cell.modified { background: rgba(255, 105, 180, 0.25); color: #fff; }
+    #cursor {
+      position: absolute;
+      width: 28px;
+      height: 28px;
+      margin: -14px 0 0 -14px;
+      border: 3px solid #00e5ff;
+      border-radius: 50%;
+      pointer-events: none;
+      display: none;
+    }
+    #cursor.stale { border-color: #555; }
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .card {
+      background: #0b1329;
+      border-radius: 10px;
+      padding: 14px 16px;
+    }
+    .card h3 {
+      margin: 0 0 6px 0;
+      font-size: 11px;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.4);
+    }
+    .stat {
+      font-size: 36px;
+      font-weight: 700;
+    }
+    .stat .sub { font-size: 14px; color: rgba(255,255,255,0.5); margin-left: 6px; font-weight: 400; }
+    .prompt { font-style: italic; font-size: 14px; line-height: 1.4; opacity: 0.8; }
+    .mini {
+      width: 100%;
+      aspect-ratio: 1 / 1;
+      border-radius: 8px;
+      background: #0b1329 center / contain no-repeat;
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <div class="stage" id="stage">
+      <div class="grid" id="grid"></div>
+      <div id="cursor"></div>
+    </div>
+    <div class="sidebar">
+      <div class="card">
+        <h3>Participant</h3>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <input id="participant-input" type="text" placeholder="id (optional)"
+                 style="flex:1; padding:8px; border-radius:6px; border:1px solid rgba(255,255,255,0.15); background:#05070f; color:inherit;" />
+          <button id="new-participant-btn"
+                  style="padding:8px 12px; border:0; border-radius:6px; background:#00e5ff; color:#05070f; font-weight:600; cursor:pointer;">
+            New
+          </button>
+        </div>
+        <div id="participant-banner" style="margin-top:8px; font-size:12px; opacity:0; transition:opacity 300ms;"></div>
+      </div>
+      <div class="card">
+        <h3>Generations</h3>
+        <div class="stat" id="stat-generations">0</div>
+      </div>
+      <div class="card">
+        <h3>Swaps</h3>
+        <div class="stat">
+          <span id="stat-swaps">0</span>
+          <span class="sub">caught <span id="stat-caught">0</span></span>
+        </div>
+      </div>
+      <div class="card">
+        <h3>Last edit</h3>
+        <div class="prompt" id="last-caption">&mdash;</div>
+      </div>
+      <div class="card">
+        <h3>Edit history</h3>
+        <ol id="edit-history" style="margin:0; padding-left:20px; font-size:13px; line-height:1.5; max-height:180px; overflow-y:auto;"></ol>
+      </div>
+      <div class="card">
+        <h3>Last generation</h3>
+        <div class="mini" id="last-image"></div>
+      </div>
+    </div>
+  </div>
+  <script type="module" src="observer.js"></script>
+</body>
+</html>

--- a/frontend/public/observer.js
+++ b/frontend/public/observer.js
@@ -1,0 +1,171 @@
+import { API_ROOT, loadRuntimeConfig } from "./config.js";
+import { openStream } from "./ws.js";
+import { gazeToSector, sectorName } from "./sectors.js";
+
+const DETECTION_WINDOW_MS = 1500;
+const EDIT_HISTORY_MAX = 10;
+
+const stage = document.getElementById("stage");
+const grid = document.getElementById("grid");
+const cursor = document.getElementById("cursor");
+const lastCaptionEl = document.getElementById("last-caption");
+const editHistoryEl = document.getElementById("edit-history");
+const lastImageEl = document.getElementById("last-image");
+const statGenerations = document.getElementById("stat-generations");
+const statSwaps = document.getElementById("stat-swaps");
+const statCaught = document.getElementById("stat-caught");
+const participantInput = document.getElementById("participant-input");
+const newParticipantBtn = document.getElementById("new-participant-btn");
+const participantBanner = document.getElementById("participant-banner");
+
+function initialState() {
+  return {
+    focusSector: null,
+    generations: 0,
+    swaps: 0,
+    caught: 0,
+    pendingDetection: null,
+    lastValidTs: 0,
+  };
+}
+
+function buildGrid(gridSize) {
+  grid.style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
+  grid.style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
+  grid.innerHTML = "";
+  const cells = [];
+  for (let r = 0; r < gridSize; r++) {
+    cells[r] = [];
+    for (let c = 0; c < gridSize; c++) {
+      const el = document.createElement("div");
+      el.className = "cell";
+      el.textContent = sectorName({ row: r, col: c });
+      grid.appendChild(el);
+      cells[r][c] = el;
+    }
+  }
+  return cells;
+}
+
+async function main() {
+  const config = await loadRuntimeConfig();
+  const cells = buildGrid(config.grid_size);
+  let state = initialState();
+
+  newParticipantBtn.addEventListener("click", async () => {
+    const id = participantInput.value.trim() || null;
+    try {
+      await fetch(`${config.generation_api}/session/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ participant_id: id }),
+      });
+    } catch (err) {
+      console.warn("New Participant POST failed", err);
+    }
+  });
+
+  function resetForNewSession(participantId) {
+    state = initialState();
+    statGenerations.textContent = "0";
+    statSwaps.textContent = "0";
+    statCaught.textContent = "0";
+    lastCaptionEl.textContent = "—";
+    editHistoryEl.innerHTML = "";
+    lastImageEl.style.backgroundImage = "";
+    for (const row of cells) for (const cell of row) cell.classList.remove("focus", "modified");
+    participantBanner.textContent = participantId
+      ? `New participant: ${participantId}`
+      : "New participant";
+    participantBanner.style.opacity = "1";
+    setTimeout(() => (participantBanner.style.opacity = "0"), 2000);
+  }
+
+  function setFocus(sector) {
+    if (state.focusSector) cells[state.focusSector.row][state.focusSector.col].classList.remove("focus");
+    state.focusSector = sector;
+    if (state.focusSector) cells[state.focusSector.row][state.focusSector.col].classList.add("focus");
+  }
+
+  function flashModified(sector) {
+    const cell = cells[sector.row][sector.col];
+    cell.classList.add("modified");
+    setTimeout(() => cell.classList.remove("modified"), 1200);
+  }
+
+  function positionCursor(smoothed, stale) {
+    const rect = stage.getBoundingClientRect();
+    cursor.style.left = `${smoothed.x_norm * rect.width}px`;
+    cursor.style.top = `${smoothed.y_norm * rect.height}px`;
+    cursor.style.display = "block";
+    cursor.classList.toggle("stale", stale);
+  }
+
+  function pushEditHistory(caption) {
+    if (!caption) return;
+    const li = document.createElement("li");
+    li.textContent = caption;
+    editHistoryEl.prepend(li);
+    while (editHistoryEl.children.length > EDIT_HISTORY_MAX) {
+      editHistoryEl.lastChild.remove();
+    }
+  }
+
+  openStream({
+    sample: ({ gaze }) => {
+      if (!gaze) return;
+      if (gaze.valid) state.lastValidTs = Date.now();
+      const stale = Date.now() - state.lastValidTs > config.gaze_stale_ms;
+      if (!gaze.valid || stale) {
+        cursor.style.display = "none";
+        setFocus(null);
+        return;
+      }
+      positionCursor(gaze, false);
+      const sector = gazeToSector(gaze, config.grid_size);
+      if (!state.focusSector
+          || sector.row !== state.focusSector.row
+          || sector.col !== state.focusSector.col) {
+        setFocus(sector);
+        if (state.pendingDetection
+            && sector.row === state.pendingDetection.targetSector.row
+            && sector.col === state.pendingDetection.targetSector.col
+            && Date.now() < state.pendingDetection.deadline) {
+          state.caught += 1;
+          statCaught.textContent = state.caught;
+          state.pendingDetection = null;
+        }
+      }
+    },
+
+    generation: ({ session_id, filename, prompt, caption }) => {
+      state.generations += 1;
+      statGenerations.textContent = state.generations;
+      const label = caption || prompt || "";
+      lastCaptionEl.textContent = label || "—";
+      pushEditHistory(caption);
+      if (session_id && filename) {
+        lastImageEl.style.backgroundImage = `url(${API_ROOT}/sessions/${session_id}/${filename})`;
+      }
+    },
+
+    swap: ({ target_row, target_col }) => {
+      state.swaps += 1;
+      statSwaps.textContent = state.swaps;
+      if (typeof target_row === "number" && typeof target_col === "number") {
+        const target = { row: target_row, col: target_col };
+        flashModified(target);
+        state.pendingDetection = {
+          targetSector: target,
+          deadline: Date.now() + DETECTION_WINDOW_MS,
+        };
+      }
+    },
+
+    session_started: ({ participant_id }) => {
+      resetForNewSession(participant_id);
+    },
+  });
+}
+
+main();

--- a/frontend/public/ws.js
+++ b/frontend/public/ws.js
@@ -1,0 +1,20 @@
+import { WS_URL } from "./config.js";
+
+export function openStream(handlers) {
+  const socket = new WebSocket(WS_URL);
+  let pingInterval = null;
+  socket.addEventListener("open", () => {
+    pingInterval = setInterval(() => socket.readyState === 1 && socket.send("ping"), 10000);
+  });
+  socket.addEventListener("message", (event) => {
+    let data;
+    try { data = JSON.parse(event.data); } catch { return; }
+    const fn = handlers[data.event];
+    if (fn) fn(data);
+  });
+  socket.addEventListener("close", () => {
+    if (pingInterval !== null) clearInterval(pingInterval);
+    setTimeout(() => openStream(handlers), 1000);
+  });
+  socket.addEventListener("error", () => socket.close());
+}

--- a/generation/openrouter.py
+++ b/generation/openrouter.py
@@ -28,53 +28,92 @@ def _extract_image(message: dict) -> Image.Image | None:
     return None
 
 
-async def generate_with_openrouter(
-    image: Image.Image, prompt: str, region: tuple[int, int, int, int], api_key: str
-) -> Image.Image:
-    """Ask OpenRouter's image model to rewrite `region` according to `prompt`."""
+def _resolve_client(client: httpx.AsyncClient | None) -> tuple[httpx.AsyncClient, bool]:
+    """Return (client, owned). Caller must aclose() iff owned."""
+    if client is not None:
+        return client, False
+    return httpx.AsyncClient(timeout=120.0), True
+
+
+async def _post_chat(payload: dict, api_key: str, client: httpx.AsyncClient) -> dict:
     if not api_key:
         raise ValueError("OPENROUTER_API_KEY not set")
+    response = await client.post(
+        f"{OPENROUTER_BASE_URL}/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/ubicomp-capstone",
+        },
+        json=payload,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"OpenRouter API error: {response.status_code} - {response.text}")
+    data = response.json()
+    choices = data.get("choices") or []
+    if not choices:
+        raise RuntimeError("No choices in OpenRouter response")
+    return choices[0].get("message", {})
 
+
+async def generate_with_openrouter(
+    image: Image.Image,
+    prompt: str,
+    region: tuple[int, int, int, int],
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> Image.Image:
+    """Cycling-mode generation: one image in, one image out."""
     buf = io.BytesIO()
     image.save(buf, format="PNG")
     img_b64 = base64.b64encode(buf.getvalue()).decode()
-
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        response = await client.post(
-            f"{OPENROUTER_BASE_URL}/chat/completions",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-                "HTTP-Referer": "https://github.com/ubicomp-capstone",
-            },
-            json={
-                "model": IMAGE_MODEL,
-                "messages": [{
-                    "role": "user",
-                    "content": [
-                        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
-                        {
-                            "type": "text",
-                            "text": (
-                                f"Modify this image by adding or changing something in the region "
-                                f"from pixel ({region[0]}, {region[1]}) to ({region[2]}, {region[3]}). "
-                                f"The modification should be: {prompt}. Return the complete modified image."
-                            ),
-                        },
-                    ],
-                }],
-                "modalities": ["image", "text"],
-            },
-        )
-
-    if response.status_code != 200:
-        raise RuntimeError(f"OpenRouter API error: {response.status_code} - {response.text}")
-
-    choices = response.json().get("choices") or []
-    if not choices:
-        raise RuntimeError("No choices in OpenRouter response")
-
-    image_out = _extract_image(choices[0].get("message", {}))
+    payload = {
+        "model": IMAGE_MODEL,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+                {
+                    "type": "text",
+                    "text": (
+                        f"Modify this image by adding or changing something in the region "
+                        f"from pixel ({region[0]}, {region[1]}) to ({region[2]}, {region[3]}). "
+                        f"The modification should be: {prompt}. Return the complete modified image."
+                    ),
+                },
+            ],
+        }],
+        "modalities": ["image", "text"],
+    }
+    owned, created = _resolve_client(client)
+    try:
+        message = await _post_chat(payload, api_key, owned)
+    finally:
+        if created:
+            await owned.aclose()
+    image_out = _extract_image(message)
     if image_out is None:
         raise RuntimeError("Model did not return an image")
     return image_out
+
+
+async def generate_with_openrouter_semantic(
+    content_parts: list[dict],
+    api_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> dict:
+    """Semantic-mode request. Returns the raw `message` dict so the caller can
+    parse image + caption itself."""
+    payload = {
+        "model": IMAGE_MODEL,
+        "messages": [{"role": "user", "content": content_parts}],
+        "modalities": ["image", "text"],
+    }
+    owned, created = _resolve_client(client)
+    try:
+        return await _post_chat(payload, api_key, owned)
+    finally:
+        if created:
+            await owned.aclose()

--- a/generation/pytest.ini
+++ b/generation/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/generation/requirements-dev.txt
+++ b/generation/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8
+pytest-asyncio>=0.23

--- a/generation/sectors.py
+++ b/generation/sectors.py
@@ -63,17 +63,18 @@ def decode_base64_image(base64_str: str) -> Image.Image:
     return Image.open(io.BytesIO(base64.b64decode(base64_str))).convert("RGB")
 
 
-def shrink_for_api(img: Image.Image, max_edge: int = 1280, quality: int = 90) -> str:
-    """Downscale + JPEG-encode a PIL image as a data URL, bounding payload size.
+def shrink_for_api(img: Image.Image, max_edge: int = 1024) -> str:
+    """Downscale + PNG-encode a PIL image as a data URL, bounding payload size.
 
-    OpenRouter rejects requests where any single image exceeds ~30MB. The
-    semantic mode sends two images per call; raw PNG canvas captures from the
-    frontend can blow past that limit on high-res displays. Shrinking to a max
-    edge of 1280 px and JPEG Q90 keeps each image at a few hundred kilobytes.
+    OpenRouter rejects requests where the combined image content exceeds ~30MB.
+    Semantic mode sends two images per call, so each one needs to fit comfortably
+    within ~12MB. 1024 px is also the native generation resolution for current
+    foundation image models — pixels above that get downsampled internally
+    before generation, so we don't gain quality by sending more.
     """
     work = img.copy()
     if max(work.size) > max_edge:
         work.thumbnail((max_edge, max_edge), Image.LANCZOS)
     buf = io.BytesIO()
-    work.convert("RGB").save(buf, format="JPEG", quality=quality)
-    return "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+    work.convert("RGB").save(buf, format="PNG", optimize=True)
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()

--- a/generation/sectors.py
+++ b/generation/sectors.py
@@ -63,6 +63,39 @@ def decode_base64_image(base64_str: str) -> Image.Image:
     return Image.open(io.BytesIO(base64.b64decode(base64_str))).convert("RGB")
 
 
+def composite_sector(
+    base: Image.Image,
+    edit: Image.Image,
+    region: tuple[int, int, int, int],
+) -> Image.Image:
+    """Paste only the target sector of `edit` onto a copy of `base`.
+
+    Foundation image models like Gemini Flash Image re-render the entire
+    canvas even when asked to modify a single region, so naively using the
+    model's full output as the next state introduces compounding tone/detail
+    drift across regions we never asked it to touch. By taking only the target
+    sector from the model's output and pasting it onto the previous state, we
+    keep non-target pixels byte-identical across iterations.
+
+    The model's output may differ from `base` in resolution; the region is
+    mapped proportionally and the cropped patch is resized (LANCZOS) to fit
+    the original sector bounds.
+    """
+    sx1, sy1, sx2, sy2 = region
+    bw, bh = base.size
+    ew, eh = edit.size
+    mx1 = sx1 * ew // bw
+    my1 = sy1 * eh // bh
+    mx2 = sx2 * ew // bw
+    my2 = sy2 * eh // bh
+    patch = edit.crop((mx1, my1, mx2, my2)).resize(
+        (sx2 - sx1, sy2 - sy1), Image.LANCZOS
+    )
+    out = base.copy()
+    out.paste(patch, (sx1, sy1))
+    return out
+
+
 def shrink_for_api(img: Image.Image, max_edge: int = 1024) -> str:
     """Downscale + PNG-encode a PIL image as a data URL, bounding payload size.
 

--- a/generation/sectors.py
+++ b/generation/sectors.py
@@ -61,3 +61,19 @@ def decode_base64_image(base64_str: str) -> Image.Image:
     if "," in base64_str:
         base64_str = base64_str.split(",", 1)[1]
     return Image.open(io.BytesIO(base64.b64decode(base64_str))).convert("RGB")
+
+
+def shrink_for_api(img: Image.Image, max_edge: int = 1280, quality: int = 90) -> str:
+    """Downscale + JPEG-encode a PIL image as a data URL, bounding payload size.
+
+    OpenRouter rejects requests where any single image exceeds ~30MB. The
+    semantic mode sends two images per call; raw PNG canvas captures from the
+    frontend can blow past that limit on high-res displays. Shrinking to a max
+    edge of 1280 px and JPEG Q90 keeps each image at a few hundred kilobytes.
+    """
+    work = img.copy()
+    if max(work.size) > max_edge:
+        work.thumbnail((max_edge, max_edge), Image.LANCZOS)
+    buf = io.BytesIO()
+    work.convert("RGB").save(buf, format="JPEG", quality=quality)
+    return "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()

--- a/generation/semantic.py
+++ b/generation/semantic.py
@@ -1,0 +1,37 @@
+"""Per-session state for the semantic generation mode."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+HISTORY_WINDOW = 5
+
+
+@dataclass
+class SemanticHistory:
+    """In-memory, single-process state keyed by session id.
+
+    Holds the most recent `HISTORY_WINDOW` edit captions plus the original
+    (pre-edit) base image for each session.
+    """
+
+    _captions: dict[str, list[str]] = field(default_factory=dict)
+    _originals: dict[str, str] = field(default_factory=dict)
+
+    def captions(self, session_id: str) -> list[str]:
+        return list(self._captions.get(session_id, []))
+
+    def append(self, session_id: str, caption: str) -> None:
+        bucket = self._captions.setdefault(session_id, [])
+        bucket.append(caption)
+        if len(bucket) > HISTORY_WINDOW:
+            del bucket[: len(bucket) - HISTORY_WINDOW]
+
+    def original(self, session_id: str) -> str | None:
+        return self._originals.get(session_id)
+
+    def set_original(self, session_id: str, image_b64: str) -> None:
+        self._originals.setdefault(session_id, image_b64)
+
+    def clear(self, session_id: str) -> None:
+        self._captions.pop(session_id, None)
+        self._originals.pop(session_id, None)

--- a/generation/semantic.py
+++ b/generation/semantic.py
@@ -1,9 +1,16 @@
 """Per-session state for the semantic generation mode."""
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
+from typing import Tuple
+
+from PIL import Image
+
+from openrouter import _extract_image
 
 HISTORY_WINDOW = 5
+CAPTION_PREFIX = "CAPTION:"
 
 
 @dataclass
@@ -81,3 +88,31 @@ def build_prompt(
         {"type": "image_url", "image_url": {"url": current_b64}},
         {"type": "text", "text": instruction},
     ]
+
+
+def _extract_caption(content) -> str | None:
+    if isinstance(content, str):
+        for line in content.splitlines():
+            line = line.strip()
+            if line.startswith(CAPTION_PREFIX):
+                return line[len(CAPTION_PREFIX):].strip() or None
+        return None
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                captured = _extract_caption(item.get("text", ""))
+                if captured:
+                    return captured
+    return None
+
+
+def parse_response(message: dict) -> Tuple[Image.Image | None, str | None]:
+    """Return `(image_or_none, caption_or_none)` from a chat-completion message."""
+    image = _extract_image(message)
+    caption = _extract_caption(message.get("content", ""))
+    return image, caption
+
+
+def degenerate_caption(index: int, sector_name: str) -> str:
+    """Fallback caption when the model returned an image but no CAPTION line."""
+    return f"edit {index} in {sector_name} at {time.strftime('%H:%M:%S')}"

--- a/generation/semantic.py
+++ b/generation/semantic.py
@@ -35,3 +35,49 @@ class SemanticHistory:
     def clear(self, session_id: str) -> None:
         self._captions.pop(session_id, None)
         self._originals.pop(session_id, None)
+
+
+def build_prompt(
+    original_b64: str,
+    current_b64: str,
+    captions: list[str],
+    region: tuple[int, int, int, int],
+    sector_name: str,
+) -> list[dict]:
+    """Assemble the `messages[0].content` payload for the semantic request."""
+    if captions:
+        history_block = "\n".join(
+            f'  {i + 1}. "{caption}"' for i, caption in enumerate(captions)
+        )
+    else:
+        history_block = "  (No prior edits yet.)"
+
+    x1, y1, x2, y2 = region
+    instruction = (
+        "You are editing an image for a change-blindness installation. A "
+        "participant is about to briefly look away from the region you are "
+        "modifying; they should only notice the change if they come back to "
+        "look at it directly.\n\n"
+        "IMAGE 1 is the ORIGINAL, unedited scene.\n"
+        "IMAGE 2 is the scene as it currently stands after several prior edits.\n\n"
+        "Prior edits applied in this session (most recent last):\n"
+        f"{history_block}\n\n"
+        "Your task:\n"
+        "- Propose ONE new edit, distinct in subject, scale, and style from every "
+        "prior edit above. Do not repeat motifs, colours, or object classes that "
+        "already appear.\n"
+        "- The edit MUST be visually contained within the pixel rectangle "
+        f"(x1={x1}, y1={y1}, x2={x2}, y2={y2}) - the {sector_name} sector of a "
+        "3x3 grid.\n"
+        "- The edit should make semantic sense given what is already in the "
+        "scene - it should feel like it belongs, not like a pasted sticker.\n"
+        "- Return the FULL modified image (not a crop), and a ONE-SENTENCE caption "
+        'of exactly what you added or changed, prefixed with "CAPTION:". '
+        "Example: CAPTION: a small paper boat now drifts across the puddle on the right."
+    )
+
+    return [
+        {"type": "image_url", "image_url": {"url": original_b64}},
+        {"type": "image_url", "image_url": {"url": current_b64}},
+        {"type": "text", "text": instruction},
+    ]

--- a/generation/server.py
+++ b/generation/server.py
@@ -349,7 +349,7 @@ async def _generate_impl(request: GenerateRequest) -> Response:
     if GENERATION_MODE == "semantic" and OPENROUTER_API_KEY:
         session_id = session_manager.current_session_id or "anon"
         # Bound payload size: OpenRouter rejects images >30MB and we send two
-        # per call. Shrink the frontend's PNG to a JPEG with a 1280 px max edge.
+        # per call. Shrink the frontend's PNG to a 1024 px optimised PNG.
         current_compressed = shrink_for_api(init_image)
         semantic_history.set_original(session_id, current_compressed)
         prior_captions = semantic_history.captions(session_id)

--- a/generation/server.py
+++ b/generation/server.py
@@ -28,6 +28,7 @@ from sectors import (
     create_mask,
     decode_base64_image,
     sector_name,
+    shrink_for_api,
 )
 from semantic import (
     SemanticHistory,
@@ -347,11 +348,14 @@ async def _generate_impl(request: GenerateRequest) -> Response:
 
     if GENERATION_MODE == "semantic" and OPENROUTER_API_KEY:
         session_id = session_manager.current_session_id or "anon"
-        semantic_history.set_original(session_id, request.image_base64)
+        # Bound payload size: OpenRouter rejects images >30MB and we send two
+        # per call. Shrink the frontend's PNG to a JPEG with a 1280 px max edge.
+        current_compressed = shrink_for_api(init_image)
+        semantic_history.set_original(session_id, current_compressed)
         prior_captions = semantic_history.captions(session_id)
         parts = build_prompt(
-            original_b64=semantic_history.original(session_id) or request.image_base64,
-            current_b64=request.image_base64,
+            original_b64=semantic_history.original(session_id) or current_compressed,
+            current_b64=current_compressed,
             captions=prior_captions,
             region=region,
             sector_name=target,

--- a/generation/server.py
+++ b/generation/server.py
@@ -153,17 +153,32 @@ class CalibrationRequest(BaseModel):
     notes: Optional[str] = None
 
 
+class StartSessionRequest(BaseModel):
+    session_id: Optional[str] = None
+    participant_id: Optional[str] = None
+
+
 @app.post("/session/start")
-async def start_session(
-    session_id: Optional[str] = None,
-    participant_id: Optional[str] = None,
-) -> dict:
+async def start_session(req: Optional[StartSessionRequest] = None) -> dict:
+    req = req or StartSessionRequest()
+    prev_sid = session_manager.current_session_id
     sid = session_manager.start_new_session(
-        session_id=session_id,
-        participant_id=participant_id,
+        session_id=req.session_id,
+        participant_id=req.participant_id,
         runtime=_runtime_snapshot(),
     )
-    return {"session_id": sid, "status": "recording", "participant_id": participant_id}
+    if prev_sid and prev_sid != sid:
+        semantic_history.clear(prev_sid)
+    if _backend_client is not None:
+        try:
+            await _backend_client.post(
+                f"{BACKEND_URL}/events/session_started",
+                json={"session_id": sid, "participant_id": req.participant_id},
+                timeout=2.0,
+            )
+        except Exception as exc:
+            print(f"session_started relay failed: {exc}")
+    return {"session_id": sid, "status": "recording", "participant_id": req.participant_id}
 
 
 @app.post("/session/blink")

--- a/generation/server.py
+++ b/generation/server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import io
 import os
 import time
@@ -42,6 +43,8 @@ PUPIL_CONFIDENCE_THRESHOLD = float(os.getenv("PUPIL_CONFIDENCE_THRESHOLD", "0.6"
 GRID_SIZE = int(os.getenv("GRID_SIZE", "3"))
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:8000")
 GENERATION_MODE = os.getenv("GENERATION_MODE", "cycling").lower()
+IDLE_THRESHOLD_SEC = int(os.getenv("IDLE_RESET_SEC", "180"))
+IDLE_TICK_SEC = 30
 PROMPTS_FILE = Path(__file__).parent / "prompts.txt"
 SECTOR_PROMPTS_FILE = Path(__file__).parent / "sector_prompts.json"
 SESSIONS_DIR = Path("/app/assets/sessions") if Path("/app/assets").exists() else Path(__file__).parent / "sessions"
@@ -69,6 +72,11 @@ prompt_bank = PromptBank(PROMPTS_FILE, SECTOR_PROMPTS_FILE)
 session_manager = SessionManager(SESSIONS_DIR)
 replay_manager = ReplayManager(session_manager)
 semantic_history = SemanticHistory()
+
+_last_generation_ts: float = time.time()
+_last_session_started_ts: float = time.time()
+_idle_task: Optional[asyncio.Task] = None
+_idle_lock: Optional[asyncio.Lock] = None  # constructed at startup on the running loop
 
 _backend_client: httpx.AsyncClient | None = None
 
@@ -101,8 +109,9 @@ class GenerateRequest(BaseModel):
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    global _backend_client, GENERATION_MODE
+    global _backend_client, GENERATION_MODE, _idle_task, _idle_lock
     _backend_client = httpx.AsyncClient()
+    _idle_lock = asyncio.Lock()
     prompt_bank.load()
     print(f"OpenRouter API Key: {'✓ Set' if OPENROUTER_API_KEY else '✗ Not set'}")
     print(f"Image model: {IMAGE_MODEL}")
@@ -112,12 +121,57 @@ async def startup_event() -> None:
     print(f"Generation mode: {GENERATION_MODE}")
     session_id = session_manager.start_new_session(runtime=_runtime_snapshot())
     print(f"Auto-started recording session: {session_id}")
+    _idle_task = asyncio.create_task(_idle_watcher())
 
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
+    if _idle_task is not None:
+        _idle_task.cancel()
     if _backend_client is not None:
         await _backend_client.aclose()
+
+
+async def _maybe_idle_reset() -> None:
+    """Rotate to a new session if no /generate and no /session/start has fired
+    for IDLE_THRESHOLD_SEC. Skips if a generation is in flight (lock held)."""
+    global _last_session_started_ts
+    if _idle_lock is None or _idle_lock.locked():
+        return
+    async with _idle_lock:
+        now = time.time()
+        stale = (
+            now - _last_generation_ts > IDLE_THRESHOLD_SEC
+            and now - _last_session_started_ts > IDLE_THRESHOLD_SEC
+        )
+        if not stale:
+            return
+        prev_sid = session_manager.current_session_id
+        sid = session_manager.start_new_session(runtime=_runtime_snapshot())
+        if prev_sid and prev_sid != sid:
+            semantic_history.clear(prev_sid)
+        _last_session_started_ts = now
+        if _backend_client is not None:
+            try:
+                await _backend_client.post(
+                    f"{BACKEND_URL}/events/session_started",
+                    json={"session_id": sid, "participant_id": None},
+                    timeout=2.0,
+                )
+            except Exception as exc:
+                print(f"idle session_started relay failed: {exc}")
+        print(f"Idle rotation: new session {sid}")
+
+
+async def _idle_watcher() -> None:
+    while True:
+        try:
+            await asyncio.sleep(IDLE_TICK_SEC)
+            await _maybe_idle_reset()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            print(f"idle watcher error: {exc}")
 
 
 @app.get("/health")
@@ -178,6 +232,8 @@ async def start_session(req: Optional[StartSessionRequest] = None) -> dict:
             )
         except Exception as exc:
             print(f"session_started relay failed: {exc}")
+    global _last_session_started_ts
+    _last_session_started_ts = time.time()
     return {"session_id": sid, "status": "recording", "participant_id": req.participant_id}
 
 
@@ -245,6 +301,13 @@ async def replay_next() -> Response:
 
 @app.post("/generate")
 async def generate(request: GenerateRequest) -> Response:
+    if _idle_lock is None:
+        return await _generate_impl(request)
+    async with _idle_lock:
+        return await _generate_impl(request)
+
+
+async def _generate_impl(request: GenerateRequest) -> Response:
     t_start = time.perf_counter()
     try:
         init_image = decode_base64_image(request.image_base64)
@@ -349,6 +412,8 @@ async def generate(request: GenerateRequest) -> Response:
     buf = io.BytesIO()
     generated_image.save(buf, format="PNG")
     buf.seek(0)
+    global _last_generation_ts
+    _last_generation_ts = time.time()
     return Response(
         content=buf.getvalue(),
         media_type="image/png",

--- a/generation/server.py
+++ b/generation/server.py
@@ -8,13 +8,18 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+import httpx
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 from pydantic import BaseModel
 
-from openrouter import IMAGE_MODEL, generate_with_openrouter
+from openrouter import (
+    IMAGE_MODEL,
+    generate_with_openrouter,
+    generate_with_openrouter_semantic,
+)
 from prompts import PromptBank
 from sectors import (
     calculate_opposite_region,
@@ -23,12 +28,20 @@ from sectors import (
     decode_base64_image,
     sector_name,
 )
+from semantic import (
+    SemanticHistory,
+    build_prompt,
+    degenerate_caption,
+    parse_response,
+)
 from session_manager import ReplayManager, SessionManager
 
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
 PUPIL_SURFACE_NAME = os.getenv("PUPIL_SURFACE_NAME", "screen")
 PUPIL_CONFIDENCE_THRESHOLD = float(os.getenv("PUPIL_CONFIDENCE_THRESHOLD", "0.6"))
 GRID_SIZE = int(os.getenv("GRID_SIZE", "3"))
+BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:8000")
+GENERATION_MODE = os.getenv("GENERATION_MODE", "cycling").lower()
 PROMPTS_FILE = Path(__file__).parent / "prompts.txt"
 SECTOR_PROMPTS_FILE = Path(__file__).parent / "sector_prompts.json"
 SESSIONS_DIR = Path("/app/assets/sessions") if Path("/app/assets").exists() else Path(__file__).parent / "sessions"
@@ -37,10 +50,10 @@ SESSIONS_DIR = Path("/app/assets/sessions") if Path("/app/assets").exists() else
 def _runtime_snapshot() -> dict[str, Any]:
     return {
         "image_model": IMAGE_MODEL,
+        "mode": GENERATION_MODE,
         "pupil_surface_name": PUPIL_SURFACE_NAME,
         "pupil_confidence_threshold": PUPIL_CONFIDENCE_THRESHOLD,
         "grid_size": GRID_SIZE,
-        "prompts_file_sha": None,  # populated at startup once prompts load
     }
 
 app = FastAPI(title="Generation Server (OpenRouter)", version="0.5.0")
@@ -55,6 +68,24 @@ app.add_middleware(
 prompt_bank = PromptBank(PROMPTS_FILE, SECTOR_PROMPTS_FILE)
 session_manager = SessionManager(SESSIONS_DIR)
 replay_manager = ReplayManager(session_manager)
+semantic_history = SemanticHistory()
+
+_backend_client: httpx.AsyncClient | None = None
+
+
+async def _notify_backend(entry: dict) -> None:
+    """Fire-and-forget: tell the backend a new image is on disk so observer /
+    feed clients get a WS push instead of polling. Failures are debug-only."""
+    if _backend_client is None or not session_manager.current_session_id:
+        return
+    try:
+        await _backend_client.post(
+            f"{BACKEND_URL}/events/generation",
+            json={"session_id": session_manager.current_session_id, **entry},
+            timeout=2.0,
+        )
+    except Exception as exc:
+        print(f"generation relay failed: {exc}")
 
 
 class GenerateRequest(BaseModel):
@@ -69,12 +100,24 @@ class GenerateRequest(BaseModel):
 
 
 @app.on_event("startup")
-def startup_event() -> None:
+async def startup_event() -> None:
+    global _backend_client, GENERATION_MODE
+    _backend_client = httpx.AsyncClient()
     prompt_bank.load()
     print(f"OpenRouter API Key: {'✓ Set' if OPENROUTER_API_KEY else '✗ Not set'}")
     print(f"Image model: {IMAGE_MODEL}")
+    if GENERATION_MODE == "semantic" and not OPENROUTER_API_KEY:
+        print("GENERATION_MODE=semantic but OPENROUTER_API_KEY missing; coercing to cycling")
+        GENERATION_MODE = "cycling"
+    print(f"Generation mode: {GENERATION_MODE}")
     session_id = session_manager.start_new_session(runtime=_runtime_snapshot())
     print(f"Auto-started recording session: {session_id}")
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    if _backend_client is not None:
+        await _backend_client.aclose()
 
 
 @app.get("/health")
@@ -219,23 +262,74 @@ async def generate(request: GenerateRequest) -> Response:
     # Mask is unused by OpenRouter but kept for any future local backend.
     _ = create_mask(init_image.size, region)
 
-    if OPENROUTER_API_KEY:
+    caption: str | None = None
+    duplicate_caption = False
+    semantic_success = False
+    generated_image = init_image
+
+    if GENERATION_MODE == "semantic" and OPENROUTER_API_KEY:
+        session_id = session_manager.current_session_id or "anon"
+        semantic_history.set_original(session_id, request.image_base64)
+        prior_captions = semantic_history.captions(session_id)
+        parts = build_prompt(
+            original_b64=semantic_history.original(session_id) or request.image_base64,
+            current_b64=request.image_base64,
+            captions=prior_captions,
+            region=region,
+            sector_name=target,
+        )
         try:
-            generated_image = await generate_with_openrouter(
-                init_image, prompt, region, OPENROUTER_API_KEY,
+            message = await generate_with_openrouter_semantic(parts, OPENROUTER_API_KEY)
+        except Exception as first_err:
+            print(f"semantic first attempt failed: {first_err} - retrying with terser prompt")
+            parts[-1]["text"] = (
+                "Propose one new small edit distinct from any prior edit, inside the "
+                f"pixel rectangle (x1={region[0]}, y1={region[1]}, x2={region[2]}, "
+                f"y2={region[3]}). Return the full modified image and a one-sentence "
+                'CAPTION: describing what you changed.'
             )
-        except Exception as api_err:
-            print(f"OpenRouter API failed: {api_err}")
+            try:
+                message = await generate_with_openrouter_semantic(parts, OPENROUTER_API_KEY)
+            except Exception as retry_err:
+                print(f"semantic retry failed: {retry_err}")
+                message = None
+        if message is not None:
+            image_out, caption = parse_response(message)
+            if image_out is not None:
+                generated_image = image_out
+                semantic_success = True
+                prior_lower = [c.lower() for c in prior_captions]
+                if caption and any(caption.lower() in p or p in caption.lower() for p in prior_lower):
+                    duplicate_caption = True
+                if caption is None:
+                    caption = degenerate_caption(session_manager.sequence_index, target)
+
+    if not semantic_success:
+        if OPENROUTER_API_KEY:
+            try:
+                generated_image = await generate_with_openrouter(
+                    init_image, prompt, region, OPENROUTER_API_KEY,
+                )
+            except Exception as api_err:
+                print(f"OpenRouter API failed: {api_err}")
+                generated_image = init_image
+        else:
+            print("No API key set - returning original image")
             generated_image = init_image
-    else:
-        print("No API key set - returning original image")
-        generated_image = init_image
+        caption = None
+        duplicate_caption = False
 
     latency_ms = (time.perf_counter() - t_start) * 1000
+    entry: dict = {}
     if session_manager.current_session_id:
-        session_manager.save_generation(
-            generated_image, target, prompt, focus_sector, latency_ms=latency_ms,
+        entry = session_manager.save_generation(
+            generated_image, target, prompt, focus_sector,
+            latency_ms=latency_ms, caption=caption,
+            duplicate_caption=duplicate_caption,
         )
+        await _notify_backend(entry)
+        if semantic_success and caption:
+            semantic_history.append(session_manager.current_session_id, caption)
 
     buf = io.BytesIO()
     generated_image.save(buf, format="PNG")

--- a/generation/server.py
+++ b/generation/server.py
@@ -25,6 +25,7 @@ from prompts import PromptBank
 from sectors import (
     calculate_opposite_region,
     calculate_sector_region,
+    composite_sector,
     create_mask,
     decode_base64_image,
     sector_name,
@@ -400,6 +401,12 @@ async def _generate_impl(request: GenerateRequest) -> Response:
             generated_image = init_image
         caption = None
         duplicate_caption = False
+
+    # Sector compositing: keep non-target pixels byte-identical to the previous
+    # state. The model re-renders the whole canvas; without this, every call
+    # introduces drift in regions we never asked it to modify.
+    if generated_image is not init_image:
+        generated_image = composite_sector(init_image, generated_image, region)
 
     latency_ms = (time.perf_counter() - t_start) * 1000
     entry: dict = {}

--- a/generation/session_manager.py
+++ b/generation/session_manager.py
@@ -47,6 +47,7 @@ class SessionManager:
             "runtime": runtime or {},
             "stats": {"blink_count": 0, "frame_drops": 0},
             "calibration": None,
+            "edit_history": [],
             "sequence": [],
         }
 
@@ -74,6 +75,8 @@ class SessionManager:
         prompt: str,
         focus_sector: str,
         latency_ms: Optional[float] = None,
+        caption: Optional[str] = None,
+        duplicate_caption: bool = False,
     ) -> Dict:
         """Save a generated image and its metadata."""
         if not self.current_session_dir:
@@ -89,11 +92,19 @@ class SessionManager:
             "target_sector": sector_name,
             "focus_sector": focus_sector,
             "prompt": prompt,
+            "caption": caption,
             "timestamp": time.time(),
             "latency_ms": latency_ms,
         }
+        if duplicate_caption:
+            entry["duplicate_caption"] = True
 
         self.metadata["sequence"].append(entry)
+        if caption:
+            history = self.metadata.setdefault("edit_history", [])
+            history.append(caption)
+            if len(history) > 5:
+                del history[: len(history) - 5]
         self._save_metadata()
 
         lat = f", {latency_ms:.0f}ms" if latency_ms is not None else ""

--- a/generation/tests/conftest.py
+++ b/generation/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for generation-service tests."""
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+
+def _tiny_png(color: tuple[int, int, int] = (12, 34, 56)) -> bytes:
+    img = Image.new("RGB", (16, 16), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def tiny_png_bytes() -> bytes:
+    return _tiny_png()
+
+
+@pytest.fixture
+def tiny_png_b64(tiny_png_bytes: bytes) -> str:
+    return f"data:image/png;base64,{base64.b64encode(tiny_png_bytes).decode()}"
+
+
+@pytest.fixture
+def fake_openrouter_response(tiny_png_b64: str):
+    """A minimal well-formed OpenRouter chat-completions payload."""
+    def _factory(caption: str | None = "a new soap bubble in the corner") -> dict:
+        content = f"CAPTION: {caption}" if caption is not None else "noop"
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": content,
+                        "images": [
+                            {"type": "image_url", "image_url": {"url": tiny_png_b64}}
+                        ],
+                    }
+                }
+            ]
+        }
+
+    return _factory

--- a/generation/tests/test_openrouter_semantic.py
+++ b/generation/tests/test_openrouter_semantic.py
@@ -1,0 +1,69 @@
+"""Tests for the semantic OpenRouter call using httpx.MockTransport."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from openrouter import generate_with_openrouter_semantic
+from semantic import build_prompt, parse_response
+
+
+def _mock_transport(status: int, body: dict):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=body)
+    return httpx.MockTransport(handler)
+
+
+async def test_semantic_request_returns_message_on_success(
+    tiny_png_b64, fake_openrouter_response,
+):
+    response_body = fake_openrouter_response("a monarch butterfly drifted in")
+    transport = _mock_transport(200, response_body)
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        message = await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+        image, caption = parse_response(message)
+    assert image is not None
+    assert caption == "a monarch butterfly drifted in"
+
+
+async def test_semantic_request_raises_on_500(tiny_png_b64):
+    transport = _mock_transport(500, {"error": "boom"})
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        with pytest.raises(RuntimeError, match="OpenRouter API error: 500"):
+            await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+
+
+async def test_semantic_request_rejects_missing_api_key(tiny_png_b64):
+    transport = _mock_transport(200, {"choices": [{"message": {}}]})
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 10, 10), "TL")
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY not set"):
+            await generate_with_openrouter_semantic(parts, "", client=client)
+
+
+async def test_semantic_payload_carries_two_images_and_instructions(tiny_png_b64):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={
+            "choices": [{"message": {
+                "content": "CAPTION: x",
+                "images": [{"type": "image_url", "image_url": {"url": tiny_png_b64}}],
+            }}],
+        })
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        parts = build_prompt(tiny_png_b64, tiny_png_b64, ["prior edit"], (0, 0, 10, 10), "TL")
+        await generate_with_openrouter_semantic(parts, "fake-key", client=client)
+
+    content = captured["body"]["messages"][0]["content"]
+    image_parts = [p for p in content if p["type"] == "image_url"]
+    assert len(image_parts) == 2
+    text_parts = [p for p in content if p["type"] == "text"]
+    assert "prior edit" in text_parts[0]["text"]

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -1,7 +1,7 @@
 """Tests for generation/semantic.py."""
 from __future__ import annotations
 
-from semantic import SemanticHistory
+from semantic import SemanticHistory, build_prompt
 
 
 def test_history_empty_for_unknown_session():
@@ -39,3 +39,50 @@ def test_clear_drops_captions_and_original():
     h.clear("sess-a")
     assert h.captions("sess-a") == []
     assert h.original("sess-a") is None
+
+
+def test_build_prompt_returns_two_images_then_text(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=[],
+        region=(0, 0, 100, 100),
+        sector_name="TL",
+    )
+    assert len(parts) == 3
+    assert parts[0]["type"] == "image_url"
+    assert parts[0]["image_url"]["url"] == tiny_png_b64
+    assert parts[1]["type"] == "image_url"
+    assert parts[2]["type"] == "text"
+
+
+def test_build_prompt_renders_region_bounds_and_sector(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=[],
+        region=(683, 0, 1024, 341),
+        sector_name="TR",
+    )
+    text = parts[2]["text"]
+    assert "(x1=683, y1=0, x2=1024, y2=341)" in text
+    assert "TR" in text
+
+
+def test_build_prompt_lists_captions_in_order(tiny_png_b64):
+    parts = build_prompt(
+        original_b64=tiny_png_b64,
+        current_b64=tiny_png_b64,
+        captions=["first edit", "second edit", "third edit"],
+        region=(0, 0, 10, 10),
+        sector_name="MC",
+    )
+    text = parts[2]["text"]
+    assert '1. "first edit"' in text
+    assert '2. "second edit"' in text
+    assert '3. "third edit"' in text
+
+
+def test_build_prompt_says_no_prior_edits_when_empty(tiny_png_b64):
+    text = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 1, 1), "TL")[2]["text"]
+    assert "No prior edits yet" in text

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -147,3 +147,49 @@ def test_shrink_for_api_passes_small_images_through():
     import base64, io
     decoded = Image.open(io.BytesIO(base64.b64decode(data_url.split(",", 1)[1])))
     assert decoded.size == (200, 200)
+
+
+def test_composite_sector_keeps_non_target_pixels_identical():
+    from PIL import Image
+    from sectors import composite_sector
+
+    base = Image.new("RGB", (300, 300), (10, 20, 30))
+    edit = Image.new("RGB", (300, 300), (200, 200, 200))
+    region = (100, 100, 200, 200)  # central square
+
+    out = composite_sector(base, edit, region)
+    # Inside the region: edit's colour
+    assert out.getpixel((150, 150)) == (200, 200, 200)
+    # Just outside: base's colour, unchanged
+    assert out.getpixel((50, 50)) == (10, 20, 30)
+    assert out.getpixel((250, 250)) == (10, 20, 30)
+    assert out.getpixel((99, 99)) == (10, 20, 30)
+
+
+def test_composite_sector_handles_resolution_mismatch():
+    from PIL import Image
+    from sectors import composite_sector
+
+    base = Image.new("RGB", (1000, 1000), (10, 20, 30))
+    # Model returned a half-res output:
+    edit = Image.new("RGB", (500, 500), (200, 200, 200))
+    region = (200, 200, 600, 600)  # in base coordinates
+
+    out = composite_sector(base, edit, region)
+    assert out.size == base.size
+    # Sampled inside the target sector → patched
+    assert out.getpixel((400, 400)) == (200, 200, 200)
+    # Sampled outside → base
+    assert out.getpixel((50, 50)) == (10, 20, 30)
+    assert out.getpixel((900, 900)) == (10, 20, 30)
+
+
+def test_composite_sector_does_not_mutate_inputs():
+    from PIL import Image
+    from sectors import composite_sector
+
+    base = Image.new("RGB", (100, 100), (10, 20, 30))
+    edit = Image.new("RGB", (100, 100), (200, 200, 200))
+    composite_sector(base, edit, (25, 25, 75, 75))
+    assert base.getpixel((50, 50)) == (10, 20, 30)
+    assert edit.getpixel((10, 10)) == (200, 200, 200)

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -124,20 +124,18 @@ def test_degenerate_caption_is_non_empty():
     assert "4" in c
 
 
-def test_shrink_for_api_caps_max_edge_and_emits_jpeg():
+def test_shrink_for_api_caps_max_edge_and_emits_png():
     from PIL import Image
     from sectors import shrink_for_api
 
     big = Image.new("RGB", (4096, 2048), (200, 100, 50))
-    data_url = shrink_for_api(big, max_edge=512, quality=80)
-    assert data_url.startswith("data:image/jpeg;base64,")
+    data_url = shrink_for_api(big, max_edge=512)
+    assert data_url.startswith("data:image/png;base64,")
 
     import base64, io
     payload = base64.b64decode(data_url.split(",", 1)[1])
     decoded = Image.open(io.BytesIO(payload))
     assert max(decoded.size) <= 512
-    # 4096-byte raw threshold confirms we're emitting a real (compressed) JPEG.
-    assert len(payload) < 200_000
 
 
 def test_shrink_for_api_passes_small_images_through():
@@ -145,7 +143,7 @@ def test_shrink_for_api_passes_small_images_through():
     from sectors import shrink_for_api
 
     small = Image.new("RGB", (200, 200), (0, 0, 0))
-    data_url = shrink_for_api(small, max_edge=1280)
+    data_url = shrink_for_api(small)
     import base64, io
     decoded = Image.open(io.BytesIO(base64.b64decode(data_url.split(",", 1)[1])))
     assert decoded.size == (200, 200)

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -1,7 +1,9 @@
 """Tests for generation/semantic.py."""
 from __future__ import annotations
 
-from semantic import SemanticHistory, build_prompt
+from PIL import Image
+
+from semantic import SemanticHistory, build_prompt, degenerate_caption, parse_response
 
 
 def test_history_empty_for_unknown_session():
@@ -86,3 +88,37 @@ def test_build_prompt_lists_captions_in_order(tiny_png_b64):
 def test_build_prompt_says_no_prior_edits_when_empty(tiny_png_b64):
     text = build_prompt(tiny_png_b64, tiny_png_b64, [], (0, 0, 1, 1), "TL")[2]["text"]
     assert "No prior edits yet" in text
+
+
+def test_parse_response_extracts_image_and_caption(fake_openrouter_response):
+    resp = fake_openrouter_response("added a rainbow glow")
+    image, caption = parse_response(resp["choices"][0]["message"])
+    assert isinstance(image, Image.Image)
+    assert caption == "added a rainbow glow"
+
+
+def test_parse_response_without_caption_returns_none_caption(fake_openrouter_response):
+    resp = fake_openrouter_response(caption=None)
+    image, caption = parse_response(resp["choices"][0]["message"])
+    assert image is not None
+    assert caption is None
+
+
+def test_parse_response_missing_image_returns_none_image():
+    image, caption = parse_response({"content": "CAPTION: nothing"})
+    assert image is None
+    assert caption == "nothing"
+
+
+def test_parse_response_handles_list_content_with_caption(fake_openrouter_response):
+    resp = fake_openrouter_response("the fern uncurled")
+    message = resp["choices"][0]["message"]
+    message["content"] = [{"type": "text", "text": "CAPTION: the fern uncurled"}]
+    image, caption = parse_response(message)
+    assert caption == "the fern uncurled"
+
+
+def test_degenerate_caption_is_non_empty():
+    c = degenerate_caption(index=4, sector_name="TL")
+    assert "TL" in c
+    assert "4" in c

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -122,3 +122,30 @@ def test_degenerate_caption_is_non_empty():
     c = degenerate_caption(index=4, sector_name="TL")
     assert "TL" in c
     assert "4" in c
+
+
+def test_shrink_for_api_caps_max_edge_and_emits_jpeg():
+    from PIL import Image
+    from sectors import shrink_for_api
+
+    big = Image.new("RGB", (4096, 2048), (200, 100, 50))
+    data_url = shrink_for_api(big, max_edge=512, quality=80)
+    assert data_url.startswith("data:image/jpeg;base64,")
+
+    import base64, io
+    payload = base64.b64decode(data_url.split(",", 1)[1])
+    decoded = Image.open(io.BytesIO(payload))
+    assert max(decoded.size) <= 512
+    # 4096-byte raw threshold confirms we're emitting a real (compressed) JPEG.
+    assert len(payload) < 200_000
+
+
+def test_shrink_for_api_passes_small_images_through():
+    from PIL import Image
+    from sectors import shrink_for_api
+
+    small = Image.new("RGB", (200, 200), (0, 0, 0))
+    data_url = shrink_for_api(small, max_edge=1280)
+    import base64, io
+    decoded = Image.open(io.BytesIO(base64.b64decode(data_url.split(",", 1)[1])))
+    assert decoded.size == (200, 200)

--- a/generation/tests/test_semantic.py
+++ b/generation/tests/test_semantic.py
@@ -1,0 +1,41 @@
+"""Tests for generation/semantic.py."""
+from __future__ import annotations
+
+from semantic import SemanticHistory
+
+
+def test_history_empty_for_unknown_session():
+    h = SemanticHistory()
+    assert h.captions("sess-a") == []
+    assert h.original("sess-a") is None
+
+
+def test_append_captions_respects_window_of_five():
+    h = SemanticHistory()
+    for i in range(8):
+        h.append("sess-a", f"edit {i}")
+    assert h.captions("sess-a") == [f"edit {i}" for i in range(3, 8)]
+
+
+def test_sessions_are_isolated():
+    h = SemanticHistory()
+    h.append("sess-a", "first")
+    h.append("sess-b", "other")
+    assert h.captions("sess-a") == ["first"]
+    assert h.captions("sess-b") == ["other"]
+
+
+def test_set_original_is_idempotent_per_session():
+    h = SemanticHistory()
+    h.set_original("sess-a", "data:image/png;base64,AAA")
+    h.set_original("sess-a", "data:image/png;base64,BBB")  # second call is a no-op
+    assert h.original("sess-a") == "data:image/png;base64,AAA"
+
+
+def test_clear_drops_captions_and_original():
+    h = SemanticHistory()
+    h.append("sess-a", "edit")
+    h.set_original("sess-a", "data:image/png;base64,AAA")
+    h.clear("sess-a")
+    assert h.captions("sess-a") == []
+    assert h.original("sess-a") is None

--- a/generation/tests/test_server_semantic.py
+++ b/generation/tests/test_server_semantic.py
@@ -98,6 +98,25 @@ def test_semantic_generate_synthesises_caption_when_model_omits_it(semantic_app)
     assert "TL" in caption
 
 
+def test_session_start_clears_semantic_history(semantic_app):
+    semantic_call = AsyncMock(return_value=_message_with_caption("first edit"))
+    with patch("server.generate_with_openrouter_semantic", semantic_call):
+        with TestClient(semantic_app.app) as client:
+            _post_generate(client)
+            old_sid = semantic_app.session_manager.current_session_id
+            assert semantic_app.semantic_history.captions(old_sid) == ["first edit"]
+
+            resp = client.post(
+                "/session/start",
+                json={"session_id": "rolled-over", "participant_id": "participant-42"},
+            )
+    assert resp.status_code == 200
+    new_sid = semantic_app.session_manager.current_session_id
+    assert new_sid != old_sid
+    assert semantic_app.semantic_history.captions(old_sid) == []
+    assert semantic_app.semantic_history.captions(new_sid) == []
+
+
 def test_duplicate_caption_is_flagged(semantic_app):
     semantic_call = AsyncMock(return_value=_message_with_caption("a monarch butterfly appeared"))
     with patch("server.generate_with_openrouter_semantic", semantic_call):

--- a/generation/tests/test_server_semantic.py
+++ b/generation/tests/test_server_semantic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import io
 import json
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -115,6 +116,31 @@ def test_session_start_clears_semantic_history(semantic_app):
     assert new_sid != old_sid
     assert semantic_app.semantic_history.captions(old_sid) == []
     assert semantic_app.semantic_history.captions(new_sid) == []
+
+
+async def test_idle_reset_rotates_session_when_stale(semantic_app, monkeypatch):
+    # Drive the app through startup so _idle_lock and session exist.
+    with TestClient(semantic_app.app):
+        sm = semantic_app.session_manager
+        first = sm.current_session_id
+        now = time.time()
+        semantic_app._last_generation_ts = now - 240
+        semantic_app._last_session_started_ts = now - 240
+        # Force a different auto-generated session id (session_<int-time>).
+        monkeypatch.setattr("session_manager.time.time", lambda: now + 10)
+        await semantic_app._maybe_idle_reset()
+        assert sm.current_session_id != first
+
+
+async def test_idle_reset_is_noop_when_recent(semantic_app):
+    with TestClient(semantic_app.app):
+        sm = semantic_app.session_manager
+        first = sm.current_session_id
+        now = time.time()
+        semantic_app._last_generation_ts = now - 30
+        semantic_app._last_session_started_ts = now - 30
+        await semantic_app._maybe_idle_reset()
+        assert sm.current_session_id == first
 
 
 def test_duplicate_caption_is_flagged(semantic_app):

--- a/generation/tests/test_server_semantic.py
+++ b/generation/tests/test_server_semantic.py
@@ -1,0 +1,112 @@
+"""Integration tests for the /generate semantic branch."""
+from __future__ import annotations
+
+import base64
+import io
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+def _png_b64() -> str:
+    img = Image.new("RGB", (24, 24), (9, 9, 9))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+@pytest.fixture
+def semantic_app(monkeypatch, tmp_path):
+    """Build a fresh FastAPI app in semantic mode with a tmp sessions dir."""
+    monkeypatch.setenv("GENERATION_MODE", "semantic")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fake-key")
+    import importlib
+    import server
+    importlib.reload(server)
+    server.SESSIONS_DIR = tmp_path
+    server.session_manager.sessions_dir = tmp_path
+    # Neutralise the backend relay — tests shouldn't hit the network.
+    server._notify_backend = AsyncMock(return_value=None)
+    yield server
+
+
+def _message_with_caption(caption: str | None) -> dict:
+    content = f"CAPTION: {caption}" if caption is not None else "noop"
+    return {
+        "content": content,
+        "images": [{"type": "image_url", "image_url": {"url": _png_b64()}}],
+    }
+
+
+def _post_generate(client: TestClient):
+    return client.post("/generate", json={
+        "image_base64": _png_b64(),
+        "focus_x": 0.5, "focus_y": 0.5,
+        "target_row": 0, "target_col": 0, "grid_size": 3,
+    })
+
+
+def test_semantic_generate_saves_caption_and_advances_history(semantic_app):
+    semantic_call = AsyncMock(return_value=_message_with_caption("added a rainbow"))
+    with patch("server.generate_with_openrouter_semantic", semantic_call):
+        with TestClient(semantic_app.app) as client:
+            resp = _post_generate(client)
+    assert resp.status_code == 200
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads(
+        (semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text()
+    )
+    assert metadata["sequence"][0]["caption"] == "added a rainbow"
+    assert metadata["edit_history"] == ["added a rainbow"]
+    assert semantic_app.semantic_history.captions(session_id) == ["added a rainbow"]
+    assert semantic_call.await_count == 1
+
+
+def test_semantic_generate_falls_back_to_cycling_on_repeated_failure(semantic_app):
+    semantic_call = AsyncMock(side_effect=RuntimeError("OpenRouter down"))
+    cycling_image = Image.new("RGB", (24, 24), (50, 50, 50))
+    cycling_call = AsyncMock(return_value=cycling_image)
+    with patch("server.generate_with_openrouter_semantic", semantic_call), \
+         patch("server.generate_with_openrouter", cycling_call):
+        with TestClient(semantic_app.app) as client:
+            resp = _post_generate(client)
+    assert resp.status_code == 200
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads(
+        (semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text()
+    )
+    assert metadata["sequence"][0]["caption"] is None
+    assert metadata["edit_history"] == []
+    assert semantic_call.await_count == 2  # original + terser retry
+    assert cycling_call.await_count == 1
+
+
+def test_semantic_generate_synthesises_caption_when_model_omits_it(semantic_app):
+    semantic_call = AsyncMock(return_value=_message_with_caption(None))
+    with patch("server.generate_with_openrouter_semantic", semantic_call):
+        with TestClient(semantic_app.app) as client:
+            _post_generate(client)
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads(
+        (semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text()
+    )
+    caption = metadata["sequence"][0]["caption"]
+    assert caption is not None
+    assert "TL" in caption
+
+
+def test_duplicate_caption_is_flagged(semantic_app):
+    semantic_call = AsyncMock(return_value=_message_with_caption("a monarch butterfly appeared"))
+    with patch("server.generate_with_openrouter_semantic", semantic_call):
+        with TestClient(semantic_app.app) as client:
+            for _ in range(2):
+                _post_generate(client)
+    session_id = semantic_app.session_manager.current_session_id
+    metadata = json.loads(
+        (semantic_app.SESSIONS_DIR / session_id / "metadata.json").read_text()
+    )
+    assert metadata["sequence"][0].get("duplicate_caption") is not True
+    assert metadata["sequence"][1].get("duplicate_caption") is True

--- a/generation/tests/test_session_manager.py
+++ b/generation/tests/test_session_manager.py
@@ -1,0 +1,82 @@
+"""Tests for SessionManager metadata extensions."""
+from __future__ import annotations
+
+import json
+
+from PIL import Image
+
+from session_manager import SessionManager
+
+
+def _tiny_image() -> Image.Image:
+    return Image.new("RGB", (8, 8), (1, 2, 3))
+
+
+def test_start_session_records_mode_when_passed_in_runtime(tmp_path):
+    sm = SessionManager(tmp_path)
+    sid = sm.start_new_session(runtime={"mode": "semantic"})
+    metadata = json.loads((tmp_path / sid / "metadata.json").read_text())
+    assert metadata["runtime"]["mode"] == "semantic"
+    assert metadata["edit_history"] == []
+
+
+def test_save_generation_persists_caption(tmp_path):
+    sm = SessionManager(tmp_path)
+    sid = sm.start_new_session(runtime={"mode": "semantic"})
+    entry = sm.save_generation(
+        _tiny_image(), "TL", "raw prompt", "BR",
+        caption="a bird landed on the ledge",
+    )
+    assert entry["caption"] == "a bird landed on the ledge"
+
+    metadata = json.loads((tmp_path / sid / "metadata.json").read_text())
+    assert metadata["sequence"][0]["caption"] == "a bird landed on the ledge"
+    assert metadata["edit_history"] == ["a bird landed on the ledge"]
+
+
+def test_edit_history_is_capped_at_five(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "semantic"})
+    for i in range(7):
+        sm.save_generation(_tiny_image(), "TL", "p", "BR", caption=f"c{i}")
+    assert sm.metadata["edit_history"] == ["c2", "c3", "c4", "c5", "c6"]
+
+
+def test_save_generation_without_caption_still_records_entry(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "cycling"})
+    entry = sm.save_generation(_tiny_image(), "TL", "p", "BR")
+    assert entry["caption"] is None
+    assert sm.metadata["edit_history"] == []
+
+
+def test_duplicate_caption_flag_is_stored_when_set(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "semantic"})
+    entry = sm.save_generation(
+        _tiny_image(), "TL", "p", "BR",
+        caption="twin", duplicate_caption=True,
+    )
+    assert entry["duplicate_caption"] is True
+
+
+def test_duplicate_caption_flag_absent_by_default(tmp_path):
+    sm = SessionManager(tmp_path)
+    sm.start_new_session(runtime={"mode": "semantic"})
+    entry = sm.save_generation(_tiny_image(), "TL", "p", "BR", caption="solo")
+    assert "duplicate_caption" not in entry
+
+
+def test_load_session_accepts_legacy_metadata_without_edit_history(tmp_path):
+    sid = "legacy-session"
+    folder = tmp_path / sid
+    folder.mkdir()
+    (folder / "metadata.json").write_text(json.dumps({
+        "session_id": sid,
+        "created_at": 0,
+        "sequence": [{"index": 0, "filename": "x.png", "target_sector": "TL",
+                      "focus_sector": "BR", "prompt": "p", "timestamp": 0}],
+    }))
+    sm = SessionManager(tmp_path)
+    metadata = sm.load_session(sid)
+    assert metadata["sequence"][0]["prompt"] == "p"

--- a/scripts/stop_stack.sh
+++ b/scripts/stop_stack.sh
@@ -10,7 +10,6 @@ kill_pattern() {
   fi
 }
 
-kill_pattern 'aria_stream_relay.py'
 kill_pattern 'uvicorn app.main:app'
 kill_pattern 'python -m http.server'
 


### PR DESCRIPTION
## Summary

- Adds a `GENERATION_MODE=semantic` path that diverges from the last 5 in-session edits via a multimodal OpenRouter call returning image + caption, with 3-minute idle auto-reset and operator-triggered participant rollover.
- Ships two second-screen pages — `feed.html` (live generation reveal) and `observer.html` (gaze cursor, 3x3 grid, swap/caught counters, edit history, New Participant button).
- Fixes persistent-fixation bugs: thread→loop boundary in `pupil_source.py` (now uses `run_coroutine_threadsafe`), heartbeat invalid samples, frontend staleness timeout, and blink relay into session metadata.
- Refactors: frontend split into ES modules with `FixationTracker` class; generation service split (sectors/openrouter/prompts/semantic); 32-test pytest suite with `httpx.MockTransport`; backend deps shrunk (dropped `torch`, `diffusers`, `transformers`).
- Renames internal `aria-*` identifiers to `blinkpatch-*` (service/network/env) and adds CLAUDE.md, design spec, and implementation plan under `docs/superpowers/`.

## Test plan

- [x] `cd generation && pytest -q` — 32 passed
- [x] `python3 -m py_compile` on all touched Python
- [ ] `docker compose up --build` smoke test with a real `OPENROUTER_API_KEY`; exercise 10 swaps → verify captions in `metadata.json`, observer edit-history scrolls, feed shows captions
- [ ] Hit **New Participant** mid-session → verify feed clears, counters reset, new session folder appears
- [ ] Leave idle 3+ min → verify auto-rotation log and new session folder
- [ ] Unset `OPENROUTER_API_KEY`, restart gen service → verify silent coerce to cycling, no 5xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)